### PR TITLE
(refactor): optimize Dockerfiles, new icon, parallel build process

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,12 +17,11 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: tessypowder/backblaze-personal-wine
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USER }}/backblaze-personal-wine
 
 
 jobs:
-  build:
-
+  build_ubuntu20:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -36,15 +35,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      #- name: Install cosign
-      #  if: github.event_name != 'pull_request'
-      #  uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
-      #  with:
-      #    cosign-release: 'v1.4.0'
-
-
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
@@ -56,7 +46,7 @@ jobs:
         uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
         with:
           registry: ${{ env.REGISTRY }}
-          username: tessypowder
+          username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
@@ -79,19 +69,40 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      #- name: Sign the published Docker image (Ubuntu 20)
-      #  if: ${{ github.event_name != 'pull_request' }}
-      #  env:
-      #    COSIGN_EXPERIMENTAL: "true"
-      #  # This step uses the identity token to provision an ephemeral certificate
-      #  # against the sigstore community Fulcio instance.
-      #  run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push-ubuntu20.outputs.digest }}
+  build_ubuntu18:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       # Build and push Ubuntu18 Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image (Ubuntu 18)
@@ -105,16 +116,3 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu18
           labels: ${{ steps.meta.outputs.labels }}
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      #- name: Sign the published Docker image (Ubuntu 18)
-      #  if: github.event_name != 'pull_request' && startsWith(github.ref, 'refs/tags/v')
-      #  env:
-      #    COSIGN_EXPERIMENTAL: "true"
-      #  # This step uses the identity token to provision an ephemeral certificate
-      #  # against the sigstore community Fulcio instance.
-      #  run: cosign sign ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build-and-push-ubuntu18.outputs.digest }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,7 +69,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-   build_ubuntu18:
+  build_ubuntu18:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -69,12 +69,13 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-  build_ubuntu18:
+   build_ubuntu18:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
       id-token: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -103,12 +104,12 @@ jobs:
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-      # Build and push Ubuntu18 Docker image with Buildx (don't push on PR)
+
+      # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image (Ubuntu 18)
         id: build-and-push-ubuntu18
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        if: startsWith(github.ref, 'refs/tags/v')
         with:
           context: .
           file: ./Dockerfile.ubuntu18

--- a/.github/workflows/dockerhub-readme-sync.yml
+++ b/.github/workflows/dockerhub-readme-sync.yml
@@ -13,6 +13,6 @@ jobs:
 
       - uses: meeDamian/sync-readme@v1.0.6
         with:
-          user: tessypowder
-          pass: ${{ secrets.DOCKERHUB_PW }}
-          slug: tessypowder/backblaze-personal-wine
+          user: ${{ secrets.DOCKERHUB_USER }}
+          pass: ${{ secrets.DOCKERHUB_TOKEN }}
+          slug: ${{ secrets.DOCKERHUB_USER }}/backblaze-personal-wine

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,3 +37,4 @@ ENV WINEDEBUG -all
 EXPOSE 5900
 
 COPY startapp.sh /startapp.sh
+RUN chmod +x /startapp.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,13 @@ RUN apt-get install -y winehq-stable
 
 RUN apt-get install -y winetricks
 
-RUN apt-get clean -y
-RUN apt-get autoremove -y
-
-#ENV DISPLAY :0
+RUN apt-get clean -y && apt-get autoremove -y
 
 ENV WINEPREFIX /config/wine/
 
-#RUN \
-#    APP_ICON_URL=https://www.backblaze.com/pics/cloud-blaze.png && \
-#    install_app_icon.sh "$APP_ICON_URL"
+RUN \
+    APP_ICON_URL=https://www.backblaze.com/blog/wp-content/uploads/2021/06/image6-1024x366.png && \
+    install_app_icon.sh "$APP_ICON_URL"
     
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-20.04
+FROM jlesage/baseimage-gui:ubuntu-20.04-v4@sha256:8043c563ef2d47944faa62fb5ab26a8dd8d26da14a3ae970fff1c5747b542ce1
 
 RUN apt-get update
 

--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-18.04
+FROM jlesage/baseimage-gui:ubuntu-18.04-v4@sha256:3cab71f85ed652a87ebf1e02e6771fca9223c889a9c15c99172320718a50abca
 
 RUN apt-get update
 

--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -1,6 +1,6 @@
 FROM jlesage/baseimage-gui:ubuntu-18.04
 
-RUN apt-get update && apt-get full-upgrade -y
+RUN apt-get update
 
 RUN apt-get install -y curl wget software-properties-common gnupg2 winbind xvfb
 
@@ -17,9 +17,9 @@ RUN apt-get clean -y && apt-get autoremove -y
 
 ENV WINEPREFIX /config/wine/
 
-#RUN \
-#    APP_ICON_URL=https://www.backblaze.com/pics/cloud-blaze.png && \
-#    install_app_icon.sh "$APP_ICON_URL"
+RUN \
+    APP_ICON_URL=https://www.backblaze.com/blog/wp-content/uploads/2021/06/image6-1024x366.png && \
+    install_app_icon.sh "$APP_ICON_URL"
     
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y locales
 

--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -37,3 +37,4 @@ ENV WINEDEBUG -all
 EXPOSE 5900
 
 COPY startapp.sh /startapp.sh
+RUN chmod +x /startapp.sh


### PR DESCRIPTION
Changes in this PR:

-) Used new jlesage/baseimage-gui v4 (the image without version tag is not maintained anymore)
-) the Dockerfiles are synchronized now (only difference is the used baseimage)
-) a new APP_ICON was added
-) the images now get built in parallel with GitHub Actions*

*) please add a new GitGub actions variable DOCKERHUB_USER to your repo with your username before merging. I wanted to test the build and so I had to use variables instead of a hard coded username 😉