### PR TITLE
(fix): build ubuntu22 and ubuntu20 images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -65,7 +65,7 @@ jobs:
           context: .
           file: ./Dockerfile.ubuntu20
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -113,7 +113,7 @@ jobs:
           context: .
           file: ./Dockerfile.ubuntu22
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu22
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -161,6 +161,6 @@ jobs:
           context: .
           file: ./Dockerfile.ubuntu18
           push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v6
+          platforms: linux/amd64
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu18
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-18.04-v4@sha256:3cab71f85ed652a87ebf1e02e6771fca9223c889a9c15c99172320718a50abca
+FROM jlesage/baseimage-gui:ubuntu-18.04-v4@sha256:8db7852ce0299e6e8ca956ef4f20dcb0ab1064f7431300e454d0f4535756334f
 
 RUN apt-get update
 

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -9,7 +9,7 @@ RUN curl -O https://dl.winehq.org/wine-builds/winehq.key
 RUN apt-key add winehq.key
 RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ focal main'
 RUN apt-get update
-RUN apt-get install -y winehq-stable=8.0.2*
+RUN apt-get install -y winehq-stable=9.0*
 
 RUN apt-get install -y winetricks
 

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-20.04-v4@sha256:8043c563ef2d47944faa62fb5ab26a8dd8d26da14a3ae970fff1c5747b542ce1
+FROM jlesage/baseimage-gui:ubuntu-20.04-v4@sha256:7727052607e9b69eeb1bfce717effa1e3abf725b431118ff35226bc63a1c72e8
 
 RUN apt-get update
 

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -9,7 +9,7 @@ RUN curl -O https://dl.winehq.org/wine-builds/winehq.key
 RUN apt-key add winehq.key
 RUN add-apt-repository 'deb https://dl.winehq.org/wine-builds/ubuntu/ jammy main'
 RUN apt-get update
-RUN apt-get install -y winehq-stable=8.0.2*
+RUN apt-get install -y winehq-stable=9.0*
 
 RUN apt-get install -y winetricks
 

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -1,4 +1,4 @@
-FROM jlesage/baseimage-gui:ubuntu-22.04-v4@sha256:bb71746f83b7f048b1bf24e06413510b59558eb26c9673abdea688024b895ba2
+FROM jlesage/baseimage-gui:ubuntu-22.04-v4@sha256:51c11dd8405ec18c65b85808ede782e548d8233705c7fb3a62d0dcf0abca55c3
 
 RUN apt-get update
 


### PR DESCRIPTION
This PR fixes the build for ubuntu22 and ubuntu20 images.

-) Wine 9.0 is now stable, so Ubuntu22 and Ubuntu20 Dockerfiles were updated with winehq-stable=9.0*
-) Wine 8.0.1 seems to be the last Ubuntu18 release for now
-) removed ARM build from GitHub actions CI, since those images are not working
-) updated SHA for all amd64 Docker baseimages