### PR TITLE
(fix): add DISPLAY environment var

### DIFF
--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -31,6 +31,8 @@ ENV DISABLE_AUTOUPDATE="false"
 
 # Disable WINE Debug messages
 ENV WINEDEBUG -all
+# Set DISPLAY to allow GUI programs to be run
+ENV DISPLAY=:0
 
 EXPOSE 5900
 

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -31,6 +31,8 @@ ENV DISABLE_AUTOUPDATE="false"
 
 # Disable WINE Debug messages
 ENV WINEDEBUG -all
+# Set DISPLAY to allow GUI programs to be run
+ENV DISPLAY=:0
 
 EXPOSE 5900
 

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -31,6 +31,8 @@ ENV DISABLE_AUTOUPDATE="false"
 
 # Disable WINE Debug messages
 ENV WINEDEBUG -all
+# Set DISPLAY to allow GUI programs to be run
+ENV DISPLAY=:0
 
 EXPOSE 5900
 


### PR DESCRIPTION
In this PR the DISPLAY=:0 environment variable was re-added to the dockerfiles.
It seems that this is now mandatory, otherwise default commands like "winecfg" will fail with an error:
`Make sure that your X server is running and that $DISPLAY is set correctly`
After adding the DISPLAY var, the default GUI apps like winecfg, explorer, etc work as expected again.