### PR TITLE
(fix): change check for wine initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,18 +288,9 @@ container.
     ````
 
 1. Open the Web Interface (on the port you specified in the docker run command, in this example 8080):
-
-    ![Step 1](https://user-images.githubusercontent.com/28999431/149661532-b4fac1b2-eb40-4e5a-b466-b2551372d6f4.png)
-
-    ![Bildschirmfoto von 2022-01-16 02-46-05](https://user-images.githubusercontent.com/28999431/149661717-f066a8b6-4add-41af-bd2d-1a20c481aa07.png)
-
-1. Click "Install" to install Mono
-
-      ![Bildschirmfoto von 2022-01-16 14-17-55](https://user-images.githubusercontent.com/28999431/149661561-6a14cf08-9d76-415e-bb51-e1b62bf0b796.png)
-
-1. Wait for the Download to finish
-
-      ![Bildschirmfoto von 2022-01-16 14-19-08](https://user-images.githubusercontent.com/28999431/149661613-272402f9-7a5e-44a2-940b-7a5314cb3924.png)
+2. You may see wine being updated, this will take a couple of minutes
+   
+   ![image](https://github.com/xela1/backblaze-personal-wine-container/assets/357319/4f401b31-8d1d-40fe-85a3-ec4637c23bf5)
 
 1. The UI of the first step of the Backblaze installer is broken on wine, but it doesn't matter, just insert the email to your backblaze account into the input field
 

--- a/startapp.sh
+++ b/startapp.sh
@@ -62,8 +62,9 @@ start_app() {
 }
 
 # Pre-initialize Wine
-if [ ! -d "$WINEPREFIX" ]; then
+if [ ! -f "${WINEPREFIX}system.reg" ]; then
     echo "WINE: Wine not initialized, initializing"
+    export WINEDLLOVERRIDES="mscoree=" #stops mono popup, we don't need mono anyway
     wineboot -i
     log_message "WINE: Initialization done"
 fi

--- a/startapp.sh
+++ b/startapp.sh
@@ -14,6 +14,7 @@ pinned_bz_version=$(sed -n '1p' "$pinned_bz_version_file")
 pinned_bz_version_url=$(sed -n '2p' "$pinned_bz_version_file")
 
 export WINEARCH="win64"
+export WINEDLLOVERRIDES="mscoree=" #stops mono popup, we don't need mono anyway
 
 # Disclaimer
 disclaimer_updatemode() {
@@ -64,7 +65,6 @@ start_app() {
 # Pre-initialize Wine
 if [ ! -f "${WINEPREFIX}system.reg" ]; then
     echo "WINE: Wine not initialized, initializing"
-    export WINEDLLOVERRIDES="mscoree=" #stops mono popup, we don't need mono anyway
     wineboot -i
     log_message "WINE: Initialization done"
 fi


### PR DESCRIPTION
I was doing some further testing and if a user attempted to use the last version of the container and it created /config/wine but failed to download the backblaze client they could be in a position where it thinks wine is already initialized when it's not.

This isn't urgent as most users can either remove the local volume they created and start again or a couple of restarts will fix, but this fix should stop the requirement for any user intervention

As an added benefit, I've found a way to suppress the mono prompt, I've tested and we don't seem to need it anyway