### PR TITLE
(feat): virtual desktop mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Automatically create symlinks for mounts (#110, thanks @xela1)
+- Enable Wine Virtual Desktop mode by default
 
 ### Changed
 - Updated known-good Backblaze version to 9.0.1.763

--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -28,6 +28,7 @@ ENV LANG en_US.UTF-8
 ENV APP_NAME="Backblaze Personal Backup"
 ENV FORCE_LATEST_UPDATE="false"
 ENV DISABLE_AUTOUPDATE="false"
+ENV DISABLE_VIRTUAL_DESKTOP="false"
 
 # Disable WINE Debug messages
 ENV WINEDEBUG -all

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -28,6 +28,7 @@ ENV LANG en_US.UTF-8
 ENV APP_NAME="Backblaze Personal Backup"
 ENV FORCE_LATEST_UPDATE="false"
 ENV DISABLE_AUTOUPDATE="false"
+ENV DISABLE_VIRTUAL_DESKTOP="false"
 
 # Disable WINE Debug messages
 ENV WINEDEBUG -all

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -28,6 +28,7 @@ ENV LANG en_US.UTF-8
 ENV APP_NAME="Backblaze Personal Backup"
 ENV FORCE_LATEST_UPDATE="false"
 ENV DISABLE_AUTOUPDATE="false"
+ENV DISABLE_VIRTUAL_DESKTOP="false"
 
 # Disable WINE Debug messages
 ENV WINEDEBUG -all

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Environment variables can be set by adding one or more arguments `-e "<VAR>=<VAL
 
 | Variable       | Description                                  | Default |
 |----------------|----------------------------------------------|---------|
+|`DISABLE_VIRTUAL_DESKTOP` | Disables Wine's Virtual Desktop Mode | false |
 |`DISABLE_AUTOUPDATE` | Disables the auto-update of the backblaze client to the latest known-good version at the time of the docker version release | false |
 |`FORCE_LATEST_UPDATE`| Forces the auto updater to download the newest version of the backblaze client from the backblaze servers instead of a known-good version from the Internet Archive | false |
 |`UMASK`| Mask that controls how file permissions are set for newly created files. The value of the mask is in octal notation.  By default, this variable is not set and the default umask of `022` is used, meaning that newly created files are readable by everyone, but only writable by the owner. See the following online umask calculator: http://wintelguy.com/umask-calc.pl | (unset) |

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Environment variables can be set by adding one or more arguments `-e "<VAR>=<VAL
 |`USER_ID`| When mounting docker-volumes, permission issues can arise between the docker host and the container. You can pass the User_ID permissions to the container with this variable. | `1000` |
 |`GROUP_ID`| When mounting docker-volumes, permission issues can arise between the docker host and the container. You can pass the Group_ID permissions to the container with this variable. | `1000` |
 |`CLEAN_TMP_DIR`| When set to `1`, all files in the `/tmp` directory are deleted during the container startup. | `1` |
-|`DISPLAY_WIDTH`| Width (in pixels) of the virtual screen's window. (Has to be divisible by 4) | `1280` |
-|`DISPLAY_HEIGHT`| Height (in pixels) of the virtual screen's window. (Has to be divisible by 4) | `768` |
+|`DISPLAY_WIDTH`| Width (in pixels) of the virtual screen's window. (Has to be divisible by 4) | `900` |
+|`DISPLAY_HEIGHT`| Height (in pixels) of the virtual screen's window. (Has to be divisible by 4) | `700` |
 |`SECURE_CONNECTION`| When set to `1`, an encrypted connection is used to access the application's GUI (either via a web browser or VNC client).  See the [Security](#security) section for more details. | `0` |
 |`VNC_PASSWORD`| Password needed to connect to the application's GUI.  See the [VNC Password](#vnc-password) section for more details. | (unset) |
 |`X11VNC_EXTRA_OPTS`| Extra options to pass to the x11vnc server running in the Docker container.  **WARNING**: For advanced users. Do not use unless you know what you are doing. | (unset) |
@@ -422,9 +422,9 @@ The `--init` flag installs a tiny process that can actually do a few init things
     ````shell
     docker exec --user app backblaze_personal_backup winecfg
     ````
-5. The window size of Backblaze Personal Backup seems to be hardcoded, so it looks nicer (less black bars on the sides) when you set the size of the virtual VNC screen to the same size. The widest dialog the client opens is the recovery dialog with 657px and the tallest dialog are the settings with 453px. In order to fit the windows decorations i would suggest a screen size of 660x476. This can be set using environment variables when creating the docker:
+5. We are using Wine's virtual desktop mode as default and are using a default screen resoluzion of 900x700 pixels. It's larger than the Backblaze UI window itself to make room for the Backblaze restore app. You can always modify the resolution as you like with DISPLAY_WIDTH and DISPLAY_HEIGHT:
     ````shell
-    docker run ... -e "DISPLAY_WIDTH=660" -e "DISPLAY_HEIGHT=476" ...
+    docker run ... -e "DISPLAY_WIDTH=1280" -e "DISPLAY_HEIGHT=800" ...
     ````
 
 # Credits

--- a/startapp.sh
+++ b/startapp.sh
@@ -39,16 +39,16 @@ done
 # Set Virtual Desktop
 cd $WINEPREFIX
 if [ "$DISABLE_VIRTUAL_DESKTOP" = "true" ]; then
+    log_message "WINE: DISABLE_VIRTUAL_DESKTOP=true - Virtual Desktop mode will be disabled"
     winetricks vd=off
-    log_message "WINE: Virtual Desktop mode disabled"
 else
-    # Check if with and height are defined
+    # Check if width and height are defined
     if [ -n "$DISPLAY_WIDTH" ] && [ -n "$DISPLAY_HEIGHT" ]; then
     log_message "WINE: Enabling Virtual Desktop mode with $DISPLAY_WIDTH:$DISPLAY_WIDTH aspect ratio"
     winetricks vd="$DISPLAY_WIDTH"x"$DISPLAY_HEIGHT"
     else
         # Default aspect ratio
-        log_message "WINE: Enable Virtual Desktop mode with recommended aspect ratio"
+        log_message "WINE: Enabling Virtual Desktop mode with recommended aspect ratio"
         winetricks vd="900x700"
     fi
 fi

--- a/startapp.sh
+++ b/startapp.sh
@@ -14,28 +14,58 @@ pinned_bz_version=$(sed -n '1p' "$pinned_bz_version_file")
 pinned_bz_version_url=$(sed -n '2p' "$pinned_bz_version_file")
 
 export WINEARCH="win64"
-export WINEDLLOVERRIDES="mscoree=" #stops mono popup, we don't need mono anyway
-
-# Disclaimer
-disclaimer_updatemode() {
-    # Check if auto-updates are disabled
-    if [ "$DISABLE_AUTOUPDATE" = "true" ]; then
-        echo "Auto-updates are disabled. Backblaze won't be updated."
-    else
-        # Check the status of FORCE_LATEST_UPDATE
-        if [ "$FORCE_LATEST_UPDATE" = "true" ]; then
-            echo "FORCE_LATEST_UPDATE is enabled which may brick your installation."
-        else
-            echo "FORCE_LATEST_UPDATE is disabled. Using known-good version of Backblaze."
-        fi
-    fi
-}
-
-disclaimer_updatemode
+export WINEDLLOVERRIDES="mscoree=" # Disable Mono installation
 
 log_message() {
     echo "$(date): $1" >> "$log_file"
 }
+
+# Pre-initialize Wine
+if [ ! -f "${WINEPREFIX}system.reg" ]; then
+    echo "WINE: Wine not initialized, initializing"
+    wineboot -i
+    log_message "WINE: Initialization done"
+fi
+
+#Configure Extra Mounts
+for x in {d..z}
+do
+    if test -d "/drive_${x}" && ! test -d "${WINEPREFIX}dosdevices/${x}:"; then
+        log_message "DRIVE: drive_${x} found but not mounted, mounting..."
+        ln -s "/drive_${x}/" "${WINEPREFIX}dosdevices/${x}:"
+    fi
+done
+
+# Set Virtual Desktop
+cd $WINEPREFIX
+if [ "$DISABLE_VIRTUAL_DESKTOP" = "true" ]; then
+    winetricks vd=off
+    log_message "WINE: Virtual Desktop mode disabled"
+else
+    # Check if with and height are defined
+    if [ -n "$DISPLAY_WIDTH" ] && [ -n "$DISPLAY_HEIGHT" ]; then
+    log_message "WINE: Enabling Virtual Desktop mode with $DISPLAY_WIDTH:$DISPLAY_WIDTH aspect ratio"
+    winetricks vd="$DISPLAY_WIDTH"x"$DISPLAY_HEIGHT"
+    else
+        # Default aspect ratio
+        log_message "WINE: Enable Virtual Desktop mode with recommended aspect ratio"
+        winetricks vd="900x700"
+    fi
+fi
+
+# Disclaimer
+    # Check if auto-updates are disabled
+if [ "$DISABLE_AUTOUPDATE" = "true" ]; then
+    echo "Auto-updates are disabled. Backblaze won't be updated."
+else
+    # Check the status of FORCE_LATEST_UPDATE
+    if [ "$FORCE_LATEST_UPDATE" = "true" ]; then
+        echo "FORCE_LATEST_UPDATE is enabled which may brick your installation."
+    else
+        echo "FORCE_LATEST_UPDATE is disabled. Using known-good version of Backblaze."
+    fi
+fi
+
 # Function to handle errors
 handle_error() {
     echo "Error: $1" >> "$log_file"
@@ -61,24 +91,6 @@ start_app() {
     wine64 "${WINEPREFIX}drive_c/Program Files (x86)/Backblaze/bzbui.exe" -noquiet &
     sleep infinity
 }
-
-# Pre-initialize Wine
-if [ ! -f "${WINEPREFIX}system.reg" ]; then
-    echo "WINE: Wine not initialized, initializing"
-    wineboot -i
-    log_message "WINE: Initialization done"
-fi
-
-#Configure Extra Mounts
-
-for x in {d..z}
-do
-    if test -d "/drive_${x}" && ! test -d "${WINEPREFIX}dosdevices/${x}:"; then
-        log_message "DRIVE: drive_${x} found but not mounted, mounting..."
-        ln -s "/drive_${x}/" "${WINEPREFIX}dosdevices/${x}:"
-    fi
-done
-
 
 if [ -f "${WINEPREFIX}drive_c/Program Files (x86)/Backblaze/bzbui.exe" ]; then
     check_url_validity() {


### PR DESCRIPTION
In this PR:

- enable Wine's virtual desktop mode by default
- add DISABLE_VIRTUAL_DESKTOP environment variable to Dockerfiles (default: false)
- check if DISPLAY_WIDTH and DISPLAY_HEIGHT are set, otherwise use a default value (900x700 to make room for the new bzrestore app)
- change the updatemode-disclaimer to a non-function since it's only called once
- reorder startapp.sh script that wine will be initialized first, then virtual desktop mode will be set
- update readme