### PR TITLE
fix: vanilla install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## 1.7.2 - 2024-02-23
+## 1.7.2 - 2024-02-24
 
 ### Changed
-- Install and update Backblaze in the background
+- Update known-good Backblaze version to 9.0.1.767
+- Update Backblaze in the background 
 - Mark ubuntu18 tag as "End of Life" and remove ubuntu18 specific troubleshooting from readme
 
 ## 1.7.1 - 2024-02-15

--- a/PINNED_BZ_VERSION
+++ b/PINNED_BZ_VERSION
@@ -1,2 +1,2 @@
-9.0.1.763
-https://web.archive.org/web/20240126203244/https://secure.backblaze.com/win32/install_backblaze.exe
+9.0.1.767
+https://web.archive.org/web/20240224185620/https://secure.backblaze.com/win32/install_backblaze.exe

--- a/startapp.sh
+++ b/startapp.sh
@@ -82,7 +82,11 @@ fetch_and_install() {
         curl -A "$custom_user_agent" -L "$pinned_bz_version_url" --output "install_backblaze.exe" || handle_error "INSTALLER: error downloading from $pinned_bz_version_url"
     fi
     log_message "INSTALLER: Starting install_backblaze.exe"
-    WINEARCH="$WINEARCH" WINEPREFIX="$WINEPREFIX" wine64 "install_backblaze.exe" -nogui || handle_error "INSTALLER: Failed to install Backblaze"
+    if [ -f "${WINEPREFIX}drive_c/Program Files (x86)/Backblaze/bzbui.exe" ]; then
+        WINEARCH="$WINEARCH" WINEPREFIX="$WINEPREFIX" wine64 "install_backblaze.exe" -nogui || handle_error "INSTALLER: Failed to install Backblaze"
+    else
+        WINEARCH="$WINEARCH" WINEPREFIX="$WINEPREFIX" wine64 "install_backblaze.exe" || handle_error "INSTALLER: Failed to install Backblaze"
+    fi
 
 }
 


### PR DESCRIPTION
This patch fixes an issue people have with new installs, where the installer won't start.
Backblaze is only updated in the background when it's already installed.

Also bumped the known-good version of Backblaze to 9.0.1.767