### PR TITLE
fix: stop forced-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.9
+
+### Changed
+- Try to prevent forced Backblaze client updates
+
 ## 1.8.1
 
 ### Changed

--- a/startapp.sh
+++ b/startapp.sh
@@ -124,6 +124,7 @@ if [ -f "${WINEPREFIX}drive_c/Program Files (x86)/Backblaze/bzbui.exe" ]; then
 
     # Check if auto-updates are disabled
     if [ "$DISABLE_AUTOUPDATE" = "true" ]; then
+        echo "127.0.0.1    f000.backblazeb2.com" >> /etc/hosts
         log_message "UPDATER: DISABLE_AUTOUPDATE=true, Auto-updates are disabled. Starting Backblaze without updating."
         start_app
     fi


### PR DESCRIPTION
In this PR:

- send official update URL to localhost to stop forced update (to gain more control over client updates).

This seems to be the only URL where official updates get pulled from. 

should fix #144 