### PR TITLE
feat: bump known-good Backblaze version, Ubuntu 22 as default

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,54 +21,6 @@ env:
 
 
 jobs:
-  build_ubuntu20:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-        
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
-
-      # Login against a Docker registry except on PR
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      # Build and push Docker image with Buildx (don't push on PR)
-      # https://github.com/docker/build-push-action
-      - name: Build and push Docker image (Ubuntu 20)
-        id: build-and-push-ubuntu20
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
-        with:
-          context: .
-          file: ./Dockerfile.ubuntu20
-          push: ${{ github.event_name != 'pull_request' }}
-          platforms: linux/amd64
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-
   build_ubuntu22:
     runs-on: ubuntu-latest
     permissions:
@@ -114,7 +66,55 @@ jobs:
           file: ./Dockerfile.ubuntu22
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu22
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_ubuntu20:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image (Ubuntu 20)
+        id: build-and-push-ubuntu20
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          file: ./Dockerfile.ubuntu20
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:ubuntu20
           labels: ${{ steps.meta.outputs.labels }}
 
   build_ubuntu18:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 1.10
+
+### Changed
+- Update known-good Backblaze version to 9.0.1.777
+- Ubuntu 22 is now the default versioned image
+
 ## 1.9
 
 ### Changed

--- a/Dockerfile.ubuntu18
+++ b/Dockerfile.ubuntu18
@@ -24,8 +24,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8 && \
-    apt-get clean -y && apt-get autoremove -y
+    update-locale LANG=en_US.UTF-8
 
 EXPOSE 5900
 

--- a/Dockerfile.ubuntu20
+++ b/Dockerfile.ubuntu20
@@ -24,8 +24,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8 && \
-    apt-get clean -y && apt-get autoremove -y
+    update-locale LANG=en_US.UTF-8
 
 EXPOSE 5900
 

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -24,8 +24,7 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y locales && \
     sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
-    update-locale LANG=en_US.UTF-8 && \
-    apt-get clean -y && apt-get autoremove -y
+    update-locale LANG=en_US.UTF-8
 
 EXPOSE 5900
 

--- a/PINNED_BZ_VERSION
+++ b/PINNED_BZ_VERSION
@@ -1,2 +1,2 @@
-9.0.1.767
-https://web.archive.org/web/20240224185620/https://secure.backblaze.com/win32/install_backblaze.exe
+9.0.1.777
+https://web.archive.org/web/20240602102732/https://secure.backblaze.com/win32/install_backblaze.exe

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Here are the main components of this image:
 
 | Tag | Description |
 |-----|-------------|
-| latest | Latest stable version of the image based on ubuntu 20 |
-| ubuntu22 | Latest stable version of the image based on ubuntu 22 |
+| latest | Latest stable version of the image based on ubuntu 22 |
+| ubuntu20 | Latest stable version of the image based on ubuntu 20 |
 | ubuntu18 | Latest stable version of the image based on ubuntu 18 **(End of Life - unmaintained)** |
-| v1.x | Versioned stable releases based on ubuntu 20 |
-| main | Automatic build of the main branch (may be unstable) based on ubuntu 20 |
+| v1.x | Versioned stable releases based on ubuntu 22 |
+| main | Automatic build of the main branch (may be unstable) based on ubuntu 22 |
 
-There are currently no versioned ubuntu22 or ubuntu18 builds.
+There are no versioned ubuntu20 or ubuntu18 builds.
 
 ### Platforms
 

--- a/startapp.sh
+++ b/startapp.sh
@@ -124,7 +124,6 @@ if [ -f "${WINEPREFIX}drive_c/Program Files (x86)/Backblaze/bzbui.exe" ]; then
 
     # Check if auto-updates are disabled
     if [ "$DISABLE_AUTOUPDATE" = "true" ]; then
-        echo "127.0.0.1    f000.backblazeb2.com" >> /etc/hosts
         log_message "UPDATER: DISABLE_AUTOUPDATE=true, Auto-updates are disabled. Starting Backblaze without updating."
         start_app
     fi


### PR DESCRIPTION
Hey,
in this PR:

- bump known-good Backblaze version to 9.0.1.777
- Promote ubuntu 22 as the default image, used for latest, main and versioned builds
- remove hosts block from v1.9 since this only works when running the command as root (will look into other workarounds if necessary for a future version)
- remove cleanup for packages in Dockerfiles. (this may lead to missing dependencies in some scenarios)