### PR TITLE
fix: work around ~0.7 Mbit/s per-connection upload slowdown with Backblaze 9.0.1+ under Wine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Slow uploads (~0.7 Mbit/s per connection) with Backblaze client 9.0.1 and newer** (#130, #186).
+  This was a Wine bug, not a Backblaze one, which is why downgrading the client "fixed" it.
+  Backblaze's uploader bursts data and then polls the socket for writability; when the poll says
+  "not writable" it waits on the socket's FD_WRITE event. Wine left `AFD_POLL_WRITE` latched in
+  `reported_events` in that path, so the server stopped watching for `POLLOUT` and the event could
+  never fire again — every burst ate the app's full ~1 second poll timeout, pinning each connection
+  at roughly `burst ÷ 1s` regardless of thread count, line speed or hardware.
+  The image now ships a `wineserver` patched to re-arm `FD_WRITE` when it reports a stream socket
+  as not writable (which is the same notification as a `send()` failing with `WSAEWOULDBLOCK`, and
+  Windows re-arms in that case). Measured with the real client: per-connection throughput went from
+  ~0.7 Mbit/s to 3.5–13.8 Mbit/s. Reported upstream as
+  [wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893); the patch lives in `patches/` and
+  should be dropped once the fix ships in WineHQ's stable packages.
+
 ## 1.11
 
 ### Changed

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -1,3 +1,34 @@
+# Build a patched wineserver. Stock wineserver stalls every upload connection for a
+# full ~1s poll timeout per burst, capping each connection at ~0.7 Mbit/s (the
+# long-standing "slow since Backblaze 9.0.1" issue, #130 / #186). See
+# patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch and
+# https://bugs.winehq.org/show_bug.cgi?id=59893. Only the wineserver binary is
+# rebuilt; the rest of Wine still comes from the WineHQ package. WINE_VERSION must
+# match the winehq-stable version installed below - the wineserver protocol is
+# version-locked, and a mismatch makes Wine refuse to start.
+FROM ubuntu:22.04 AS wineserver-builder
+ARG DEBIAN_FRONTEND=noninteractive
+ARG WINE_VERSION=11.0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential flex bison ca-certificates wget xz-utils patch && \
+    rm -rf /var/lib/apt/lists/*
+COPY patches/ /patches/
+RUN set -eux; \
+    wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION%.*}.x/wine-${WINE_VERSION}.tar.xz" \
+      || wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION}/wine-${WINE_VERSION}.tar.xz"; \
+    tar -xf "wine-${WINE_VERSION}.tar.xz"; \
+    cd "wine-${WINE_VERSION}"; \
+    for p in /patches/*.patch; do echo "applying $p"; patch -p1 < "$p"; done; \
+    ./configure --enable-win64 --without-x --without-freetype --without-mingw \
+        --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
+        --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
+        --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
+        --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null; \
+    make -j"$(nproc)" server/wineserver; \
+    strip server/wineserver; \
+    install -Dm755 server/wineserver /out/wineserver
+
 FROM jlesage/baseimage-gui:ubuntu-22.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -48,6 +79,24 @@ RUN set -eux; \
     xvfb-run -a sh -c "wine reg add 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f && wine reg add 'HKCU\\Software\\Wine\\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f && wineserver -w"; \
     rm -f /defaults/rundll32.exe.manifest; \
     chown -R 1000:1000 /defaults
+
+# Swap in the patched wineserver (see the builder stage at the top of this file).
+# Verified against the packaged Wine: if WineHQ ships a different version than
+# WINE_VERSION, the build fails loudly here rather than shipping a broken image.
+ARG WINE_VERSION=11.0
+COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
+RUN set -eux; \
+    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1 | sed -n 's/^Wine \([0-9.]*\).*/\1/p')"; \
+    if [ "$packaged" != "$WINE_VERSION" ]; then \
+        echo "ERROR: winehq-stable is Wine $packaged but the patched wineserver was built" >&2; \
+        echo "       from Wine $WINE_VERSION. The wineserver protocol is version-locked." >&2; \
+        echo "       Rebuild with --build-arg WINE_VERSION=$packaged." >&2; \
+        exit 1; \
+    fi; \
+    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
+    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
+    chmod 755 /opt/wine-stable/bin/wineserver; \
+    /opt/wine-stable/bin/wineserver --version
 
 COPY rootfs/ /
 # Must be world-readable/executable: the baseimage runs the app as a non-root user

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -1,3 +1,34 @@
+# Build a patched wineserver. Stock wineserver stalls every upload connection for a
+# full ~1s poll timeout per burst, capping each connection at ~0.7 Mbit/s (the
+# long-standing "slow since Backblaze 9.0.1" issue, #130 / #186). See
+# patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch and
+# https://bugs.winehq.org/show_bug.cgi?id=59893. Only the wineserver binary is
+# rebuilt; the rest of Wine still comes from the WineHQ package. WINE_VERSION must
+# match the winehq-stable version installed below - the wineserver protocol is
+# version-locked, and a mismatch makes Wine refuse to start.
+FROM ubuntu:24.04 AS wineserver-builder
+ARG DEBIAN_FRONTEND=noninteractive
+ARG WINE_VERSION=11.0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential flex bison ca-certificates wget xz-utils patch && \
+    rm -rf /var/lib/apt/lists/*
+COPY patches/ /patches/
+RUN set -eux; \
+    wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION%.*}.x/wine-${WINE_VERSION}.tar.xz" \
+      || wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION}/wine-${WINE_VERSION}.tar.xz"; \
+    tar -xf "wine-${WINE_VERSION}.tar.xz"; \
+    cd "wine-${WINE_VERSION}"; \
+    for p in /patches/*.patch; do echo "applying $p"; patch -p1 < "$p"; done; \
+    ./configure --enable-win64 --without-x --without-freetype --without-mingw \
+        --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
+        --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
+        --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
+        --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null; \
+    make -j"$(nproc)" server/wineserver; \
+    strip server/wineserver; \
+    install -Dm755 server/wineserver /out/wineserver
+
 FROM jlesage/baseimage-gui:ubuntu-24.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -48,6 +79,24 @@ RUN set -eux; \
     xvfb-run -a sh -c "wine reg add 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f && wine reg add 'HKCU\\Software\\Wine\\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f && wineserver -w"; \
     rm -f /defaults/rundll32.exe.manifest; \
     chown -R 1000:1000 /defaults
+
+# Swap in the patched wineserver (see the builder stage at the top of this file).
+# Verified against the packaged Wine: if WineHQ ships a different version than
+# WINE_VERSION, the build fails loudly here rather than shipping a broken image.
+ARG WINE_VERSION=11.0
+COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
+RUN set -eux; \
+    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1 | sed -n 's/^Wine \([0-9.]*\).*/\1/p')"; \
+    if [ "$packaged" != "$WINE_VERSION" ]; then \
+        echo "ERROR: winehq-stable is Wine $packaged but the patched wineserver was built" >&2; \
+        echo "       from Wine $WINE_VERSION. The wineserver protocol is version-locked." >&2; \
+        echo "       Rebuild with --build-arg WINE_VERSION=$packaged." >&2; \
+        exit 1; \
+    fi; \
+    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
+    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
+    chmod 755 /opt/wine-stable/bin/wineserver; \
+    /opt/wine-stable/bin/wineserver --version
 
 COPY rootfs/ /
 # Must be world-readable/executable: the baseimage runs the app as a non-root user

--- a/README.md
+++ b/README.md
@@ -43,6 +43,50 @@ This docker should just work for most people. But if you for example have a comp
 
 Still please be attentive during the install process: The docker by design has read/write access to all the data you are trying to back up and if you make a grave mistake you could delete stuff.
 
+## Upload Speed / Patched wineserver
+
+If you have seen uploads crawl at roughly **0.7 Mbit/s per connection** since Backblaze client
+9.0.1 — no matter how many backup threads, how fast your line is, or how beefy your NAS is — that
+was a **Wine bug, not a Backblaze bug**. It is fixed in this image; you do not need to downgrade the
+Backblaze client any more.
+
+<details>
+<summary>What was actually wrong</summary>
+
+Backblaze's uploader (`bztransmit`) drives each connection like curl does: send a burst, then poll
+the socket to ask whether it is still writable, and if the answer is "no", wait on the socket's
+`WSAEventSelect` **FD_WRITE** event with a ~1 second timeout.
+
+`FD_WRITE` is a *latched* event on Windows: once you have been told the socket is writable, you are
+not told again until a `send()` fails with `WSAEWOULDBLOCK`. Wine models that latch with
+`reported_events`, and `sock_get_poll_events()` computes its poll mask as
+`sock->mask & ~sock->reported_events` — so while the latch is set, **the server stops asking the
+kernel about `POLLOUT` at all**. Wine only cleared the latch when an actual `send()` failed.
+
+An app that instead learns "not writable" from a *poll* therefore ended up waiting on an event that
+could never be signalled: the socket drained a few milliseconds later, but nothing was watching for
+writability any more. Every burst blocked for the app's full 1 second timeout, which caps a
+connection at `burst ÷ 1s` ≈ 0.7 Mbit/s. Linux makes this easy to hit because it withholds `POLLOUT`
+until the send queue drains well below `SO_SNDBUF` (and the queue can even sit *above* `SO_SNDBUF`
+while data is in flight), whereas Windows reports a stream socket writable whenever `send()` would
+accept any data at all. On real Windows the poll simply answers "yes, writable" and the app never
+waits — which is why this only ever affected Wine users.
+
+The fix (`patches/`) re-arms `FD_WRITE` when the server reports a stream socket as not writable,
+since that is the same notification as a `send()` failing with `WSAEWOULDBLOCK`. The image rebuilds
+**only** the `wineserver` binary from the matching WineHQ source; everything else still comes from
+the WineHQ package.
+
+Measured with the real Backblaze client: per-connection throughput went from ~0.7 Mbit/s to
+**3.5–13.8 Mbit/s**. Aggregate throughput scales with your thread count as it always did, but
+*single-connection* operations — most importantly the `bz_comb` state POST, which has a hard
+600 second timeout — are no longer starved. Oversized `bz_done` state files were previously able to
+wedge the client permanently for exactly this reason.
+
+Reported upstream as [wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893). Once the fix
+ships in WineHQ's stable packages, the builder stage and `patches/` can simply be deleted.
+</details>
+
 ## Docker Images
 ### Content
 Here are the main components of this image:

--- a/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch
+++ b/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch
@@ -1,0 +1,71 @@
+From: Backblaze-personal-wine-container contributors
+Subject: [PATCH] server: Re-arm FD_WRITE when reporting a stream socket not writable.
+
+Backblaze's uploader (bztransmit, client >= 9.0.1) drives each connection with a
+curl-style loop: burst data, then poll the socket for writability, and if the poll
+says "not writable" wait on the socket's WSAEventSelect FD_WRITE event with a ~1 s
+timeout.
+
+Under Wine that loop stalls for the full timeout on every iteration, pinning each
+connection at ~0.7 Mbit/s regardless of thread count, line speed or hardware. It is
+the cause of the long-standing "slow upload after 9.0.1" reports (container
+discussion #130 / issue #186) and of Wine bug 59893.
+
+Mechanism:
+
+  - The application has been told FD_WRITE once, so AFD_POLL_WRITE is latched in
+    sock->reported_events.
+  - sock_get_poll_events() computes its mask as "sock->mask & ~sock->reported_events",
+    so with AFD_POLL_WRITE latched it stops asking the kernel for POLLOUT at all.
+  - poll_socket() then reports "not writable" (Linux withholds POLLOUT until the
+    send queue drains well below SO_SNDBUF; it can even sit above SO_SNDBUF while
+    data is in flight).
+  - Windows re-arms FD_WRITE whenever a send fails with WSAEWOULDBLOCK, so the app
+    is woken as soon as the socket drains. Wine only clears the latch in
+    send_socket_completion_callback(), i.e. when an actual send fails. An app that
+    learns "not writable" from a *poll* rather than from a failed send therefore
+    waits on an event that can never be signalled: the socket drains milliseconds
+    later, but nothing is watching POLLOUT any more. It sleeps until its own poll
+    timeout expires.
+
+Telling an application that a socket is not writable is semantically the same
+notification as a send failing with WSAEWOULDBLOCK, so re-arm FD_WRITE in that case
+too. The socket is then re-selected for POLLOUT and the event fires as soon as it
+drains.
+
+Measured with the real Backblaze client (Wine 11.0, Ubuntu 22.04 container):
+per-connection throughput rises from ~0.7 Mbit/s to 3.5-13.8 Mbit/s. With a
+synthetic reproducer of the same I/O pattern against a 20 ms-RTT sink:
+0.93 Mbit/s -> 38 Mbit/s (and -> 74 Mbit/s when combined with the writability fix
+in wine MR !11272), with the ~1 s poll timeouts dropping to zero.
+
+Upstream: https://bugs.winehq.org/show_bug.cgi?id=59893
+See also: https://gitlab.winehq.org/wine/wine/-/merge_requests/11272 (complementary;
+this patch is effective with or without it).
+---
+--- a/server/sock.c
++++ b/server/sock.c
+@@ -3653,7 +3653,23 @@ static void poll_socket( struct sock *poll_sock, struct async *async, int exclus
+         pollfd.fd = get_unix_fd( sock->fd );
+         pollfd.events = poll_flags_from_afd( sock, mask );
+         if (pollfd.events >= 0 && poll( &pollfd, 1, 0 ) >= 0)
++        {
++            /* If we are about to report that the socket is not writable, that is
++             * equivalent to a send() failing with WSAEWOULDBLOCK, and Windows
++             * re-arms FD_WRITE in that case. Without re-arming, AFD_POLL_WRITE
++             * stays latched in reported_events, sock_get_poll_events() drops
++             * POLLOUT from the poll mask, and a socket that drains later never
++             * signals FD_WRITE - the application sleeps until its poll timeout. */
++            if ((mask & AFD_POLL_WRITE) && !(pollfd.revents & (POLLOUT | POLLERR | POLLHUP)) &&
++                sock->type == WS_SOCK_STREAM && sock->state == SOCK_CONNECTED && !sock->wr_shutdown &&
++                (sock->reported_events & AFD_POLL_WRITE))
++            {
++                sock->pending_events &= ~AFD_POLL_WRITE;
++                sock->reported_events &= ~AFD_POLL_WRITE;
++                sock_reselect( sock );
++            }
+             sock_poll_event( sock->fd, pollfd.revents );
++        }
+
+         /* FIXME: do other error conditions deserve a similar treatment? */
+         if (sock->state != SOCK_CONNECTING && sock->errors[AFD_POLL_BIT_CONNECT_ERR] && (mask & AFD_POLL_CONNECT_ERR))


### PR DESCRIPTION
# Fix the ~0.7 Mbit/s per-connection upload cap (Backblaze client ≥ 9.0.1)

Fixes #130. Fixes #186.

## TL;DR

The "uploads are slow since Backblaze 9.0.1" problem is a **Wine bug, not a Backblaze bug** — which
is exactly why downgrading the client appeared to fix it, and why nobody could explain the
oddly-specific ~730 kbit/s-per-thread number.

This PR ships a `wineserver` patched to re-arm `FD_WRITE` when it reports a stream socket as not
writable. Measured with the real client, per-connection throughput goes from **~0.7 Mbit/s to
3.5–13.8 Mbit/s**. No client downgrade needed.

## The bug

`bztransmit` drives each connection the way curl does:

1. burst some data,
2. poll the socket to ask whether it is still writable,
3. if the poll says "not writable", wait on the socket's `WSAEventSelect` **FD_WRITE** event with a
   ~1 second timeout.

`FD_WRITE` is a *latched* event on Windows: once you have been told a socket is writable, you are not
told again until a `send()` fails with `WSAEWOULDBLOCK`. Wine models the latch with
`sock->reported_events`, and `sock_get_poll_events()` computes its poll mask as
`sock->mask & ~sock->reported_events` — so while the latch is set, **the server stops asking the
kernel about `POLLOUT` altogether**. Wine only cleared the latch from
`send_socket_completion_callback()`, i.e. when an actual `send()` failed.

So an app that learns "not writable" from a **poll** rather than from a failed **send** ends up
waiting on an event that can never be signalled. The socket drains a few milliseconds later, but
nothing is watching writability any more. The app sleeps until its own poll timeout expires.

Every burst therefore costs the app's full ~1 second timeout, capping a connection at
`burst ÷ 1s` ≈ 0.7 Mbit/s — **independent of thread count, line speed, or hardware**, which is
precisely the reported symptom.

Linux makes this trivial to hit: it withholds `POLLOUT` until the send queue drains well below
`SO_SNDBUF` (and the queue can even sit *above* `SO_SNDBUF` while data is in flight), whereas Windows
reports a stream socket writable whenever `send()` would accept any data at all. On real Windows the
poll in step 2 simply answers "yes, writable", the app never waits, and the whole pathology is
invisible. Hence: Wine-only.

## The fix

Reporting a socket as not writable *is* the same notification as a `send()` failing with
`WSAEWOULDBLOCK`, and Windows re-arms `FD_WRITE` in that case. So do the same, and re-select the
socket for `POLLOUT`, in `poll_socket()`:

```c
if ((mask & AFD_POLL_WRITE) && !(pollfd.revents & (POLLOUT | POLLERR | POLLHUP)) &&
    sock->type == WS_SOCK_STREAM && sock->state == SOCK_CONNECTED && !sock->wr_shutdown &&
    (sock->reported_events & AFD_POLL_WRITE))
{
    sock->pending_events &= ~AFD_POLL_WRITE;
    sock->reported_events &= ~AFD_POLL_WRITE;
    sock_reselect( sock );
}
```

The event now fires as soon as the socket drains, instead of never.

Only the **`wineserver`** binary is rebuilt, from the matching WineHQ source tarball; the rest of
Wine still comes from the WineHQ package. A build-time guard compares the packaged Wine version
against `WINE_VERSION` and **fails loudly on a mismatch** rather than shipping a broken image — the
wineserver protocol is version-locked, so a silent mismatch would make Wine refuse to start. When
WineHQ bumps stable, bump `WINE_VERSION` (or pass `--build-arg WINE_VERSION=…`).

## Measurements

Real Backblaze client 10.0.2.1047, Wine 11.0, Ubuntu 22.04 image, ~1 Gbit line:

| | per-connection |
|---|---|
| stock wineserver | ~730 kbit/s (and rock-steady at that number, for months) |
| patched wineserver | **2,671 – 13,807 kbit/s** |

Synthetic reproducer of the same I/O pattern (burst → poll → wait on latched FD_WRITE) against a
20 ms-RTT sink, run under the image's own Wine:

| wineserver | throughput | 1s poll timeouts |
|---|---|---|
| stock | 0.93 Mbit/s | 8 |
| **this patch** | **38.0 Mbit/s** | **0** |
| this patch + [wine MR !11272] | 74.2 Mbit/s | 0 |

[wine MR !11272] is a complementary, still-unmerged upstream change that makes the *writability
report itself* Windows-accurate. It is **not** sufficient on its own (0.93 → 1.85 Mbit/s only,
timeouts unchanged at 8) — because it correctly reports "not writable" when the send queue is genuinely
over-full, and without this PR's re-arm the app then sleeps the full second anyway. The two compose:
this patch removes the stall, that one removes some of the remaining waits. I have only included the
re-arm patch here, since it is the one that actually fixes the reported issue.

[wine MR !11272]: https://gitlab.winehq.org/wine/wine/-/merge_requests/11272

## Why this matters beyond raw speed

Aggregate throughput always scaled with thread count (each connection had its own independent 1 s
metronome), which is why the cap was easy to mistake for "just slow" and hard to pin down.

But **single-connection** operations can never be helped by more threads — above all the `bz_comb`
state POST, which has a hard 600 second server-side timeout. At 86 KB/s that window only fits a
~55 MB comb. Once a user's `bz_done` state file grows past roughly 300 MB (easy with a large or
small-file-heavy backup set), the comb POST can *never* complete, the client retries it forever while
holding its four-hour lock, and the backup wedges permanently. I hit exactly this, repeatedly, and it
is unrecoverable without discarding backup state. With the patch the same POST runs at multi-Mbit/s
and completes in seconds.

## How this was found

`tx_queue` was 0 on every upload socket (so: not the network, not TCP, not a throttle), and the
upload threads sat ~99% of their time blocked reading the wineserver reply pipe. Instrumenting
`poll_socket()` showed the smoking gun — the poll reporting `revents=0` with `AFD_POLL_WRITE` still
latched in `reported_events`, while the send queue was over-full:

```
revents=4  outq=98304   sndbuf=131072   ← room → writable ✓
revents=0  outq=141904  sndbuf=131072   ← over-full → not writable, and FD_WRITE latched → 1s stall
```

## Upstream

Reported to WineHQ as [bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893). Once the fix lands
in WineHQ's stable packages, the builder stage and `patches/` can simply be deleted and the image goes
back to using the packaged `wineserver` unmodified.

## Testing

- `docker build -f Dockerfile.ubuntu22 …` builds clean; the version guard was verified to fail the
  build correctly on a deliberate mismatch.
- The built image ships a `wineserver` that differs from the packaged one and reports `Wine 11.0`.
- Reproducer under the built image: 38.5 Mbit/s, 0 timeouts.
- Running in production on a UGREEN DXP8800 (~1.3 TB backup set) through a full container recreate;
  the client kept its identity and state, and per-connection speed is 5–20× higher.
- Not yet built/tested on `Dockerfile.ubuntu24`, though the change there is identical.