### PR TITLE
fix: work around ~0.7 Mbit/s per-connection upload slowdown under Wine (#264 with review feedback applied)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USER }}/backblaze-personal-wine
+  IMAGE_NAME: ${{ github.event_name == 'pull_request' && 'local/backblaze-personal-wine' || format('{0}/backblaze-personal-wine', secrets.DOCKERHUB_USER) }}
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,21 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- **Slow uploads (~0.7 Mbit/s per connection) with Backblaze client 9.0.1 and newer** (#130, #186).
-  This was a Wine bug, not a Backblaze one, which is why downgrading the client "fixed" it.
-  Backblaze's uploader bursts data and then polls the socket for writability; when the poll says
-  "not writable" it waits on the socket's FD_WRITE event. Wine left `AFD_POLL_WRITE` latched in
-  `reported_events` in that path, so the server stopped watching for `POLLOUT` and the event could
-  never fire again — every burst ate the app's full ~1 second poll timeout, pinning each connection
-  at roughly `burst ÷ 1s` regardless of thread count, line speed or hardware.
-  The image now ships a `wineserver` patched to re-arm `FD_WRITE` when it reports a stream socket
-  as not writable (which is the same notification as a `send()` failing with `WSAEWOULDBLOCK`, and
-  Windows re-arms in that case). Measured with the real client: per-connection throughput went from
-  ~0.7 Mbit/s to 3.5–13.8 Mbit/s. Reported upstream as
-  [wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893); the patch lives in `patches/` and
-  should be dropped once the fix ships in WineHQ's stable packages.
-
 ## 1.11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Slow uploads (~0.7 Mbit/s per connection) with Backblaze client 9.0.1 and newer** (#130, #186).
+  This was a Wine bug, not a Backblaze one, which is why downgrading the client "fixed" it.
+  Backblaze's uploader bursts data and then polls the socket for writability; when the poll says
+  "not writable" it waits on the socket's FD_WRITE event. Wine left `AFD_POLL_WRITE` latched in
+  `reported_events` in that path, so the server stopped watching for `POLLOUT` and the event could
+  never fire again — every burst ate the app's full ~1 second poll timeout, pinning each connection
+  at roughly `burst ÷ 1s` regardless of thread count, line speed or hardware.
+  The image now ships a `wineserver` patched to re-arm `FD_WRITE` when it reports a stream socket
+  as not writable (which is the same notification as a `send()` failing with `WSAEWOULDBLOCK`, and
+  Windows re-arms in that case). Measured with the real client: per-connection throughput went from
+  ~0.7 Mbit/s to 3.5–13.8 Mbit/s. Reported upstream as
+  [wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893); the patch lives in `patches/` and
+  should be dropped once the fix ships in WineHQ's stable packages.
+
 ## 1.11
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix the ~0.7 Mbit/s per-connection upload slowdown affecting Backblaze client 9.0.1 and later under Wine ([#130](https://github.com/JonathanTreffler/backblaze-personal-wine-container/discussions/130), [#186](https://github.com/JonathanTreffler/backblaze-personal-wine-container/issues/186))
+
 ## 1.11
 
 ### Changed

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -3,34 +3,27 @@
 # long-standing "slow since Backblaze 9.0.1" issue, #130 / #186). See
 # patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch and
 # https://bugs.winehq.org/show_bug.cgi?id=59893. Only the wineserver binary is
-# rebuilt; the rest of Wine still comes from the WineHQ package. WINE_VERSION must
-# match the winehq-stable version installed below - the wineserver protocol is
-# version-locked, and a mismatch makes Wine refuse to start.
+# rebuilt, from the WineHQ *source* package for the exact same suite and package
+# revision as the winehq-stable binaries installed below - the wineserver
+# protocol is version-locked, so the two must come from one source revision.
 FROM ubuntu:22.04 AS wineserver-builder
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINE_VERSION=11.0
+ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential flex bison ca-certificates wget xz-utils patch && \
+        build-essential dpkg-dev flex bison ca-certificates curl patch xz-utils && \
     rm -rf /var/lib/apt/lists/*
 COPY patches/ /patches/
-RUN set -eux; \
-    wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION%.*}.x/wine-${WINE_VERSION}.tar.xz" \
-      || wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION}/wine-${WINE_VERSION}.tar.xz"; \
-    tar -xf "wine-${WINE_VERSION}.tar.xz"; \
-    cd "wine-${WINE_VERSION}"; \
-    for p in /patches/*.patch; do echo "applying $p"; patch -p1 < "$p"; done; \
-    ./configure --enable-win64 --without-x --without-freetype --without-mingw \
-        --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
-        --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
-        --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
-        --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null; \
-    make -j"$(nproc)" server/wineserver; \
-    strip server/wineserver; \
-    install -Dm755 server/wineserver /out/wineserver
+COPY scripts/build-wineserver.sh /usr/local/bin/build-wineserver.sh
+RUN chmod 755 /usr/local/bin/build-wineserver.sh && \
+    /usr/local/bin/build-wineserver.sh \
+        jammy "$WINE_PACKAGE_VERSION" \
+        "/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch" \
+        /out/wineserver
 
 FROM jlesage/baseimage-gui:ubuntu-22.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
+ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1
 
 ENV WINEPREFIX=/config/wine/
 ENV LANG=en_US.UTF-8
@@ -55,11 +48,39 @@ RUN dpkg --add-architecture i386 && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key && \
     curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources -o /etc/apt/sources.list.d/winehq-jammy.sources && \
     apt-get update && \
-    apt-get install -y --install-recommends winehq-stable && \
+    apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
     curl -fsSL https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -o /usr/local/bin/winetricks && \
     chmod +x /usr/local/bin/winetricks && \
     sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Swap in the patched wineserver (see the builder stage at the top of this file)
+# before the Wine prefix below is prepared, so the wineboot / winetricks /
+# wineserver -w steps exercise the patched server too.
+#
+# Both halves of Wine are pinned to WINE_PACKAGE_VERSION: the binaries via the
+# apt install above, the wineserver via the source package it was built from.
+# Verify that here and fail the build rather than ship an image whose Wine
+# binaries and wineserver came from different revisions.
+COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
+RUN set -eux; \
+    installed="$(dpkg-query -W -f='${Version}' winehq-stable)"; \
+    if [ "$installed" != "$WINE_PACKAGE_VERSION" ]; then \
+        echo "ERROR: winehq-stable is $installed but the patched wineserver was built" >&2; \
+        echo "       from the $WINE_PACKAGE_VERSION source package." >&2; \
+        exit 1; \
+    fi; \
+    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1)"; \
+    patched="$(/opt/wine-stable/bin/wineserver.patched --version 2>&1)"; \
+    if [ "$packaged" != "$patched" ]; then \
+        echo "ERROR: packaged wineserver reports '$packaged' but the patched one" >&2; \
+        echo "       reports '$patched'. The wineserver protocol is version-locked." >&2; \
+        exit 1; \
+    fi; \
+    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
+    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
+    chmod 755 /opt/wine-stable/bin/wineserver; \
+    /opt/wine-stable/bin/wineserver --version
 
 # Build a ready-to-use wine prefix at image build time so the user's first start
 # is fast (a quick copy instead of a multi-minute .NET install). The template has
@@ -79,24 +100,6 @@ RUN set -eux; \
     xvfb-run -a sh -c "wine reg add 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f && wine reg add 'HKCU\\Software\\Wine\\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f && wineserver -w"; \
     rm -f /defaults/rundll32.exe.manifest; \
     chown -R 1000:1000 /defaults
-
-# Swap in the patched wineserver (see the builder stage at the top of this file).
-# Verified against the packaged Wine: if WineHQ ships a different version than
-# WINE_VERSION, the build fails loudly here rather than shipping a broken image.
-ARG WINE_VERSION=11.0
-COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
-RUN set -eux; \
-    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1 | sed -n 's/^Wine \([0-9.]*\).*/\1/p')"; \
-    if [ "$packaged" != "$WINE_VERSION" ]; then \
-        echo "ERROR: winehq-stable is Wine $packaged but the patched wineserver was built" >&2; \
-        echo "       from Wine $WINE_VERSION. The wineserver protocol is version-locked." >&2; \
-        echo "       Rebuild with --build-arg WINE_VERSION=$packaged." >&2; \
-        exit 1; \
-    fi; \
-    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
-    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
-    chmod 755 /opt/wine-stable/bin/wineserver; \
-    /opt/wine-stable/bin/wineserver --version
 
 COPY rootfs/ /
 # Must be world-readable/executable: the baseimage runs the app as a non-root user

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -1,3 +1,34 @@
+# Build a patched wineserver. Stock wineserver stalls every upload connection for a
+# full ~1s poll timeout per burst, capping each connection at ~0.7 Mbit/s (the
+# long-standing "slow since Backblaze 9.0.1" issue, #130 / #186). See
+# patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch and
+# https://bugs.winehq.org/show_bug.cgi?id=59893. Only the wineserver binary is
+# rebuilt; the rest of Wine still comes from the WineHQ package. WINE_VERSION must
+# match the winehq-stable version installed below - the wineserver protocol is
+# version-locked, and a mismatch makes Wine refuse to start.
+FROM ubuntu:22.04 AS wineserver-builder
+ARG DEBIAN_FRONTEND=noninteractive
+ARG WINE_VERSION=11.0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential flex bison ca-certificates wget xz-utils patch && \
+    rm -rf /var/lib/apt/lists/*
+COPY patches/ /patches/
+RUN set -eux; \
+    wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION%.*}.x/wine-${WINE_VERSION}.tar.xz" \
+      || wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION}/wine-${WINE_VERSION}.tar.xz"; \
+    tar -xf "wine-${WINE_VERSION}.tar.xz"; \
+    cd "wine-${WINE_VERSION}"; \
+    for p in /patches/*.patch; do echo "applying $p"; patch -p1 < "$p"; done; \
+    ./configure --enable-win64 --without-x --without-freetype --without-mingw \
+        --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
+        --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
+        --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
+        --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null; \
+    make -j"$(nproc)" server/wineserver; \
+    strip server/wineserver; \
+    install -Dm755 server/wineserver /out/wineserver
+
 FROM jlesage/baseimage-gui:ubuntu-22.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -48,6 +79,24 @@ RUN set -eux; \
     xvfb-run -a sh -c "wine reg add 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f && wine reg add 'HKCU\\Software\\Wine\\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f && wineserver -w"; \
     rm -f /defaults/rundll32.exe.manifest; \
     chown -R 1000:1000 /defaults
+
+# Swap in the patched wineserver (see the builder stage at the top of this file).
+# Verified against the packaged Wine: if WineHQ ships a different version than
+# WINE_VERSION, the build fails loudly here rather than shipping a broken image.
+ARG WINE_VERSION=11.0
+COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
+RUN set -eux; \
+    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1 | sed -n 's/^Wine \([0-9.]*\).*/\1/p')"; \
+    if [ "$packaged" != "$WINE_VERSION" ]; then \
+        echo "ERROR: winehq-stable is Wine $packaged but the patched wineserver was built" >&2; \
+        echo "       from Wine $WINE_VERSION. The wineserver protocol is version-locked." >&2; \
+        echo "       Rebuild with --build-arg WINE_VERSION=$packaged." >&2; \
+        exit 1; \
+    fi; \
+    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
+    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
+    chmod 755 /opt/wine-stable/bin/wineserver; \
+    /opt/wine-stable/bin/wineserver --version
 
 COPY rootfs/ /
 # Must be world-readable/executable: the baseimage runs the app as a non-root user

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -6,9 +6,10 @@
 # rebuilt, from the WineHQ *source* package for the exact same suite and package
 # revision as the winehq-stable binaries installed below - the wineserver
 # protocol is version-locked, so the two must come from one source revision.
+ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1
 FROM ubuntu:22.04 AS wineserver-builder
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1
+ARG WINE_PACKAGE_VERSION
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential dpkg-dev flex bison ca-certificates curl patch xz-utils && \
@@ -23,7 +24,7 @@ RUN chmod 755 /usr/local/bin/build-wineserver.sh && \
 
 FROM jlesage/baseimage-gui:ubuntu-22.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1
+ARG WINE_PACKAGE_VERSION
 
 ENV WINEPREFIX=/config/wine/
 ENV LANG=en_US.UTF-8

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -3,34 +3,27 @@
 # long-standing "slow since Backblaze 9.0.1" issue, #130 / #186). See
 # patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch and
 # https://bugs.winehq.org/show_bug.cgi?id=59893. Only the wineserver binary is
-# rebuilt; the rest of Wine still comes from the WineHQ package. WINE_VERSION must
-# match the winehq-stable version installed below - the wineserver protocol is
-# version-locked, and a mismatch makes Wine refuse to start.
+# rebuilt, from the WineHQ *source* package for the exact same suite and package
+# revision as the winehq-stable binaries installed below - the wineserver
+# protocol is version-locked, so the two must come from one source revision.
 FROM ubuntu:24.04 AS wineserver-builder
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINE_VERSION=11.0
+ARG WINE_PACKAGE_VERSION=11.0.0.0~noble-1
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        build-essential flex bison ca-certificates wget xz-utils patch && \
+        build-essential dpkg-dev flex bison ca-certificates curl patch xz-utils && \
     rm -rf /var/lib/apt/lists/*
 COPY patches/ /patches/
-RUN set -eux; \
-    wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION%.*}.x/wine-${WINE_VERSION}.tar.xz" \
-      || wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION}/wine-${WINE_VERSION}.tar.xz"; \
-    tar -xf "wine-${WINE_VERSION}.tar.xz"; \
-    cd "wine-${WINE_VERSION}"; \
-    for p in /patches/*.patch; do echo "applying $p"; patch -p1 < "$p"; done; \
-    ./configure --enable-win64 --without-x --without-freetype --without-mingw \
-        --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
-        --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
-        --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
-        --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null; \
-    make -j"$(nproc)" server/wineserver; \
-    strip server/wineserver; \
-    install -Dm755 server/wineserver /out/wineserver
+COPY scripts/build-wineserver.sh /usr/local/bin/build-wineserver.sh
+RUN chmod 755 /usr/local/bin/build-wineserver.sh && \
+    /usr/local/bin/build-wineserver.sh \
+        noble "$WINE_PACKAGE_VERSION" \
+        "/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch" \
+        /out/wineserver
 
 FROM jlesage/baseimage-gui:ubuntu-24.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
+ARG WINE_PACKAGE_VERSION=11.0.0.0~noble-1
 
 ENV WINEPREFIX=/config/wine/
 ENV LANG=en_US.UTF-8
@@ -55,11 +48,39 @@ RUN dpkg --add-architecture i386 && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key && \
     curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources -o /etc/apt/sources.list.d/winehq-noble.sources && \
     apt-get update && \
-    apt-get install -y --install-recommends winehq-stable && \
+    apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
     curl -fsSL https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -o /usr/local/bin/winetricks && \
     chmod +x /usr/local/bin/winetricks && \
     sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Swap in the patched wineserver (see the builder stage at the top of this file)
+# before the Wine prefix below is prepared, so the wineboot / winetricks /
+# wineserver -w steps exercise the patched server too.
+#
+# Both halves of Wine are pinned to WINE_PACKAGE_VERSION: the binaries via the
+# apt install above, the wineserver via the source package it was built from.
+# Verify that here and fail the build rather than ship an image whose Wine
+# binaries and wineserver came from different revisions.
+COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
+RUN set -eux; \
+    installed="$(dpkg-query -W -f='${Version}' winehq-stable)"; \
+    if [ "$installed" != "$WINE_PACKAGE_VERSION" ]; then \
+        echo "ERROR: winehq-stable is $installed but the patched wineserver was built" >&2; \
+        echo "       from the $WINE_PACKAGE_VERSION source package." >&2; \
+        exit 1; \
+    fi; \
+    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1)"; \
+    patched="$(/opt/wine-stable/bin/wineserver.patched --version 2>&1)"; \
+    if [ "$packaged" != "$patched" ]; then \
+        echo "ERROR: packaged wineserver reports '$packaged' but the patched one" >&2; \
+        echo "       reports '$patched'. The wineserver protocol is version-locked." >&2; \
+        exit 1; \
+    fi; \
+    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
+    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
+    chmod 755 /opt/wine-stable/bin/wineserver; \
+    /opt/wine-stable/bin/wineserver --version
 
 # Build a ready-to-use wine prefix at image build time so the user's first start
 # is fast (a quick copy instead of a multi-minute .NET install). The template has
@@ -79,24 +100,6 @@ RUN set -eux; \
     xvfb-run -a sh -c "wine reg add 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f && wine reg add 'HKCU\\Software\\Wine\\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f && wineserver -w"; \
     rm -f /defaults/rundll32.exe.manifest; \
     chown -R 1000:1000 /defaults
-
-# Swap in the patched wineserver (see the builder stage at the top of this file).
-# Verified against the packaged Wine: if WineHQ ships a different version than
-# WINE_VERSION, the build fails loudly here rather than shipping a broken image.
-ARG WINE_VERSION=11.0
-COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
-RUN set -eux; \
-    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1 | sed -n 's/^Wine \([0-9.]*\).*/\1/p')"; \
-    if [ "$packaged" != "$WINE_VERSION" ]; then \
-        echo "ERROR: winehq-stable is Wine $packaged but the patched wineserver was built" >&2; \
-        echo "       from Wine $WINE_VERSION. The wineserver protocol is version-locked." >&2; \
-        echo "       Rebuild with --build-arg WINE_VERSION=$packaged." >&2; \
-        exit 1; \
-    fi; \
-    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
-    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
-    chmod 755 /opt/wine-stable/bin/wineserver; \
-    /opt/wine-stable/bin/wineserver --version
 
 COPY rootfs/ /
 # Must be world-readable/executable: the baseimage runs the app as a non-root user

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -1,3 +1,34 @@
+# Build a patched wineserver. Stock wineserver stalls every upload connection for a
+# full ~1s poll timeout per burst, capping each connection at ~0.7 Mbit/s (the
+# long-standing "slow since Backblaze 9.0.1" issue, #130 / #186). See
+# patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch and
+# https://bugs.winehq.org/show_bug.cgi?id=59893. Only the wineserver binary is
+# rebuilt; the rest of Wine still comes from the WineHQ package. WINE_VERSION must
+# match the winehq-stable version installed below - the wineserver protocol is
+# version-locked, and a mismatch makes Wine refuse to start.
+FROM ubuntu:24.04 AS wineserver-builder
+ARG DEBIAN_FRONTEND=noninteractive
+ARG WINE_VERSION=11.0
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential flex bison ca-certificates wget xz-utils patch && \
+    rm -rf /var/lib/apt/lists/*
+COPY patches/ /patches/
+RUN set -eux; \
+    wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION%.*}.x/wine-${WINE_VERSION}.tar.xz" \
+      || wget -q "https://dl.winehq.org/wine/source/${WINE_VERSION}/wine-${WINE_VERSION}.tar.xz"; \
+    tar -xf "wine-${WINE_VERSION}.tar.xz"; \
+    cd "wine-${WINE_VERSION}"; \
+    for p in /patches/*.patch; do echo "applying $p"; patch -p1 < "$p"; done; \
+    ./configure --enable-win64 --without-x --without-freetype --without-mingw \
+        --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
+        --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
+        --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
+        --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null; \
+    make -j"$(nproc)" server/wineserver; \
+    strip server/wineserver; \
+    install -Dm755 server/wineserver /out/wineserver
+
 FROM jlesage/baseimage-gui:ubuntu-24.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -48,6 +79,24 @@ RUN set -eux; \
     xvfb-run -a sh -c "wine reg add 'HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\SideBySide' /v PreferExternalManifest /t REG_DWORD /d 1 /f && wine reg add 'HKCU\\Software\\Wine\\WineDbg' /v ShowCrashDialog /t REG_DWORD /d 0 /f && wineserver -w"; \
     rm -f /defaults/rundll32.exe.manifest; \
     chown -R 1000:1000 /defaults
+
+# Swap in the patched wineserver (see the builder stage at the top of this file).
+# Verified against the packaged Wine: if WineHQ ships a different version than
+# WINE_VERSION, the build fails loudly here rather than shipping a broken image.
+ARG WINE_VERSION=11.0
+COPY --from=wineserver-builder /out/wineserver /opt/wine-stable/bin/wineserver.patched
+RUN set -eux; \
+    packaged="$(/opt/wine-stable/bin/wineserver --version 2>&1 | sed -n 's/^Wine \([0-9.]*\).*/\1/p')"; \
+    if [ "$packaged" != "$WINE_VERSION" ]; then \
+        echo "ERROR: winehq-stable is Wine $packaged but the patched wineserver was built" >&2; \
+        echo "       from Wine $WINE_VERSION. The wineserver protocol is version-locked." >&2; \
+        echo "       Rebuild with --build-arg WINE_VERSION=$packaged." >&2; \
+        exit 1; \
+    fi; \
+    mv /opt/wine-stable/bin/wineserver /opt/wine-stable/bin/wineserver.orig; \
+    mv /opt/wine-stable/bin/wineserver.patched /opt/wine-stable/bin/wineserver; \
+    chmod 755 /opt/wine-stable/bin/wineserver; \
+    /opt/wine-stable/bin/wineserver --version
 
 COPY rootfs/ /
 # Must be world-readable/executable: the baseimage runs the app as a non-root user

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -6,9 +6,10 @@
 # rebuilt, from the WineHQ *source* package for the exact same suite and package
 # revision as the winehq-stable binaries installed below - the wineserver
 # protocol is version-locked, so the two must come from one source revision.
+ARG WINE_PACKAGE_VERSION=11.0.0.0~noble-1
 FROM ubuntu:24.04 AS wineserver-builder
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINE_PACKAGE_VERSION=11.0.0.0~noble-1
+ARG WINE_PACKAGE_VERSION
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential dpkg-dev flex bison ca-certificates curl patch xz-utils && \
@@ -23,7 +24,7 @@ RUN chmod 755 /usr/local/bin/build-wineserver.sh && \
 
 FROM jlesage/baseimage-gui:ubuntu-24.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
-ARG WINE_PACKAGE_VERSION=11.0.0.0~noble-1
+ARG WINE_PACKAGE_VERSION
 
 ENV WINEPREFIX=/config/wine/
 ENV LANG=en_US.UTF-8

--- a/README.md
+++ b/README.md
@@ -43,6 +43,50 @@ This docker should just work for most people. But if you for example have a comp
 
 Still please be attentive during the install process: The docker by design has read/write access to all the data you are trying to back up and if you make a grave mistake you could delete stuff.
 
+## Upload Speed / Patched wineserver
+
+If you have seen uploads crawl at roughly **0.7 Mbit/s per connection** since Backblaze client
+9.0.1 — no matter how many backup threads, how fast your line is, or how beefy your NAS is — that
+was a **Wine bug, not a Backblaze bug**. It is fixed in this image; you do not need to downgrade the
+Backblaze client any more.
+
+<details>
+<summary>What was actually wrong</summary>
+
+Backblaze's uploader (`bztransmit`) drives each connection like curl does: send a burst, then poll
+the socket to ask whether it is still writable, and if the answer is "no", wait on the socket's
+`WSAEventSelect` **FD_WRITE** event with a ~1 second timeout.
+
+`FD_WRITE` is a *latched* event on Windows: once you have been told the socket is writable, you are
+not told again until a `send()` fails with `WSAEWOULDBLOCK`. Wine models that latch with
+`reported_events`, and `sock_get_poll_events()` computes its poll mask as
+`sock->mask & ~sock->reported_events` — so while the latch is set, **the server stops asking the
+kernel about `POLLOUT` at all**. Wine only cleared the latch when an actual `send()` failed.
+
+An app that instead learns "not writable" from a *poll* therefore ended up waiting on an event that
+could never be signalled: the socket drained a few milliseconds later, but nothing was watching for
+writability any more. Every burst blocked for the app's full 1 second timeout, which caps a
+connection at `burst ÷ 1s` ≈ 0.7 Mbit/s. Linux makes this easy to hit because it withholds `POLLOUT`
+until the send queue drains well below `SO_SNDBUF` (and the queue can even sit *above* `SO_SNDBUF`
+while data is in flight), whereas Windows reports a stream socket writable whenever `send()` would
+accept any data at all. On real Windows the poll simply answers "yes, writable" and the app never
+waits — which is why this only ever affected Wine users.
+
+The fix (`patches/`) re-arms `FD_WRITE` when the server reports a stream socket as not writable,
+since that is the same notification as a `send()` failing with `WSAEWOULDBLOCK`. The image rebuilds
+**only** the `wineserver` binary from the matching WineHQ source; everything else still comes from
+the WineHQ package.
+
+Measured with the real Backblaze client: per-connection throughput went from ~0.7 Mbit/s to
+**3.5–13.8 Mbit/s**. Aggregate throughput scales with your thread count as it always did, but
+*single-connection* operations — most importantly the `bz_comb` state POST, which has a hard
+600 second timeout — are no longer starved. Oversized `bz_done` state files were previously able to
+wedge the client permanently for exactly this reason.
+
+Reported upstream as [wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893). Once the fix
+ships in WineHQ's stable packages, the builder stage and `patches/` can simply be deleted.
+</details>
+
 ## Docker Images
 ### Content
 Here are the main components of this image:

--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ container.
 
 ## Troubleshooting
 
+- Upload speed is limited to about 0.7 Mbit/s per connection
+
+  - **Explanation**: Backblaze client 9.0.1 and later can hit a Wine socket-notification issue that makes each upload connection wait for a timeout after sending a block of data.
+
+  - **Solution**: Update to a current container image. The image includes a patched `wineserver` built from the matching pinned WineHQ source package. The issue has been reported upstream as [Wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893).
+
+  - **More information**: [Discussion #130](https://github.com/JonathanTreffler/backblaze-personal-wine-container/discussions/130) and [issue #186](https://github.com/JonathanTreffler/backblaze-personal-wine-container/issues/186)
+
 - The Backblaze Installer says it recognized a server operating system
 
   ![Bildschirmfoto von 2022-01-16 14-41-04](https://user-images.githubusercontent.com/28999431/149662713-b7b27862-59b6-432a-a3c3-327f939a7292.png)

--- a/README.md
+++ b/README.md
@@ -43,50 +43,6 @@ This docker should just work for most people. But if you for example have a comp
 
 Still please be attentive during the install process: The docker by design has read/write access to all the data you are trying to back up and if you make a grave mistake you could delete stuff.
 
-## Upload Speed / Patched wineserver
-
-If you have seen uploads crawl at roughly **0.7 Mbit/s per connection** since Backblaze client
-9.0.1 — no matter how many backup threads, how fast your line is, or how beefy your NAS is — that
-was a **Wine bug, not a Backblaze bug**. It is fixed in this image; you do not need to downgrade the
-Backblaze client any more.
-
-<details>
-<summary>What was actually wrong</summary>
-
-Backblaze's uploader (`bztransmit`) drives each connection like curl does: send a burst, then poll
-the socket to ask whether it is still writable, and if the answer is "no", wait on the socket's
-`WSAEventSelect` **FD_WRITE** event with a ~1 second timeout.
-
-`FD_WRITE` is a *latched* event on Windows: once you have been told the socket is writable, you are
-not told again until a `send()` fails with `WSAEWOULDBLOCK`. Wine models that latch with
-`reported_events`, and `sock_get_poll_events()` computes its poll mask as
-`sock->mask & ~sock->reported_events` — so while the latch is set, **the server stops asking the
-kernel about `POLLOUT` at all**. Wine only cleared the latch when an actual `send()` failed.
-
-An app that instead learns "not writable" from a *poll* therefore ended up waiting on an event that
-could never be signalled: the socket drained a few milliseconds later, but nothing was watching for
-writability any more. Every burst blocked for the app's full 1 second timeout, which caps a
-connection at `burst ÷ 1s` ≈ 0.7 Mbit/s. Linux makes this easy to hit because it withholds `POLLOUT`
-until the send queue drains well below `SO_SNDBUF` (and the queue can even sit *above* `SO_SNDBUF`
-while data is in flight), whereas Windows reports a stream socket writable whenever `send()` would
-accept any data at all. On real Windows the poll simply answers "yes, writable" and the app never
-waits — which is why this only ever affected Wine users.
-
-The fix (`patches/`) re-arms `FD_WRITE` when the server reports a stream socket as not writable,
-since that is the same notification as a `send()` failing with `WSAEWOULDBLOCK`. The image rebuilds
-**only** the `wineserver` binary from the matching WineHQ source; everything else still comes from
-the WineHQ package.
-
-Measured with the real Backblaze client: per-connection throughput went from ~0.7 Mbit/s to
-**3.5–13.8 Mbit/s**. Aggregate throughput scales with your thread count as it always did, but
-*single-connection* operations — most importantly the `bz_comb` state POST, which has a hard
-600 second timeout — are no longer starved. Oversized `bz_done` state files were previously able to
-wedge the client permanently for exactly this reason.
-
-Reported upstream as [wine bug 59893](https://bugs.winehq.org/show_bug.cgi?id=59893). Once the fix
-ships in WineHQ's stable packages, the builder stage and `patches/` can simply be deleted.
-</details>
-
 ## Docker Images
 ### Content
 Here are the main components of this image:

--- a/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch
+++ b/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch
@@ -45,7 +45,7 @@ this patch is effective with or without it).
 ---
 --- a/server/sock.c
 +++ b/server/sock.c
-@@ -3653,7 +3653,23 @@ static void poll_socket( struct sock *poll_sock, struct async *async, int exclus
+@@ -3653,7 +3653,28 @@ static void poll_socket( struct sock *poll_sock, struct async *async, int exclus
          pollfd.fd = get_unix_fd( sock->fd );
          pollfd.events = poll_flags_from_afd( sock, mask );
          if (pollfd.events >= 0 && poll( &pollfd, 1, 0 ) >= 0)
@@ -55,12 +55,17 @@ this patch is effective with or without it).
 +             * re-arms FD_WRITE in that case. Without re-arming, AFD_POLL_WRITE
 +             * stays latched in reported_events, sock_get_poll_events() drops
 +             * POLLOUT from the poll mask, and a socket that drains later never
-+             * signals FD_WRITE - the application sleeps until its poll timeout. */
-+            if ((mask & AFD_POLL_WRITE) && !(pollfd.revents & (POLLOUT | POLLERR | POLLHUP)) &&
-+                sock->type == WS_SOCK_STREAM && sock->state == SOCK_CONNECTED && !sock->wr_shutdown &&
-+                (sock->reported_events & AFD_POLL_WRITE))
++             * signals FD_WRITE - the application sleeps until its poll timeout.
++             * Do not re-arm while an FD_WRITE is still pending, as that event
++             * has not yet been consumed by the application. */
++            if ((mask & AFD_POLL_WRITE) &&
++                !(pollfd.revents & (POLLOUT | POLLERR | POLLHUP)) &&
++                sock->type == WS_SOCK_STREAM &&
++                sock->state == SOCK_CONNECTED &&
++                !sock->wr_shutdown &&
++                (sock->reported_events & AFD_POLL_WRITE) &&
++                !(sock->pending_events & AFD_POLL_WRITE))
 +            {
-+                sock->pending_events &= ~AFD_POLL_WRITE;
 +                sock->reported_events &= ~AFD_POLL_WRITE;
 +                sock_reselect( sock );
 +            }

--- a/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch
+++ b/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch
@@ -1,0 +1,71 @@
+From: Backblaze-personal-wine-container contributors
+Subject: [PATCH] server: Re-arm FD_WRITE when reporting a stream socket not writable.
+
+Backblaze's uploader (bztransmit, client >= 9.0.1) drives each connection with a
+curl-style loop: burst data, then poll the socket for writability, and if the poll
+says "not writable" wait on the socket's WSAEventSelect FD_WRITE event with a ~1 s
+timeout.
+
+Under Wine that loop stalls for the full timeout on every iteration, pinning each
+connection at ~0.7 Mbit/s regardless of thread count, line speed or hardware. It is
+the cause of the long-standing "slow upload after 9.0.1" reports (container
+discussion #130 / issue #186) and of Wine bug 59893.
+
+Mechanism:
+
+  - The application has been told FD_WRITE once, so AFD_POLL_WRITE is latched in
+    sock->reported_events.
+  - sock_get_poll_events() computes its mask as "sock->mask & ~sock->reported_events",
+    so with AFD_POLL_WRITE latched it stops asking the kernel for POLLOUT at all.
+  - poll_socket() then reports "not writable" (Linux withholds POLLOUT until the
+    send queue drains well below SO_SNDBUF; it can even sit above SO_SNDBUF while
+    data is in flight).
+  - Windows re-arms FD_WRITE whenever a send fails with WSAEWOULDBLOCK, so the app
+    is woken as soon as the socket drains. Wine only clears the latch in
+    send_socket_completion_callback(), i.e. when an actual send fails. An app that
+    learns "not writable" from a *poll* rather than from a failed send therefore
+    waits on an event that can never be signalled: the socket drains milliseconds
+    later, but nothing is watching POLLOUT any more. It sleeps until its own poll
+    timeout expires.
+
+Telling an application that a socket is not writable is semantically the same
+notification as a send failing with WSAEWOULDBLOCK, so re-arm FD_WRITE in that case
+too. The socket is then re-selected for POLLOUT and the event fires as soon as it
+drains.
+
+Measured with the real Backblaze client (Wine 11.0, Ubuntu 22.04 container):
+per-connection throughput rises from ~0.7 Mbit/s to 3.5-13.8 Mbit/s. With a
+synthetic reproducer of the same I/O pattern against a 20 ms-RTT sink:
+0.93 Mbit/s -> 38 Mbit/s (and -> 74 Mbit/s when combined with the writability fix
+in wine MR !11272), with the ~1 s poll timeouts dropping to zero.
+
+Upstream: https://bugs.winehq.org/show_bug.cgi?id=59893
+See also: https://gitlab.winehq.org/wine/wine/-/merge_requests/11272 (complementary;
+this patch is effective with or without it).
+---
+--- a/server/sock.c
++++ b/server/sock.c
+@@ -3653,7 +3653,23 @@ static void poll_socket( struct sock *poll_sock, struct async *async, int exclus
+         pollfd.fd = get_unix_fd( sock->fd );
+         pollfd.events = poll_flags_from_afd( sock, mask );
+         if (pollfd.events >= 0 && poll( &pollfd, 1, 0 ) >= 0)
++        {
++            /* If we are about to report that the socket is not writable, that is
++             * equivalent to a send() failing with WSAEWOULDBLOCK, and Windows
++             * re-arms FD_WRITE in that case. Without re-arming, AFD_POLL_WRITE
++             * stays latched in reported_events, sock_get_poll_events() drops
++             * POLLOUT from the poll mask, and a socket that drains later never
++             * signals FD_WRITE - the application sleeps until its poll timeout. */
++            if ((mask & AFD_POLL_WRITE) && !(pollfd.revents & (POLLOUT | POLLERR | POLLHUP)) &&
++                sock->type == WS_SOCK_STREAM && sock->state == SOCK_CONNECTED && !sock->wr_shutdown &&
++                (sock->reported_events & AFD_POLL_WRITE))
++            {
++                sock->pending_events &= ~AFD_POLL_WRITE;
++                sock->reported_events &= ~AFD_POLL_WRITE;
++                sock_reselect( sock );
++            }
+             sock_poll_event( sock->fd, pollfd.revents );
++        }
+
+         /* FIXME: do other error conditions deserve a similar treatment? */
+         if (sock->state != SOCK_CONNECTING && sock->errors[AFD_POLL_BIT_CONNECT_ERR] && (mask & AFD_POLL_CONNECT_ERR))

--- a/scripts/build-wineserver.sh
+++ b/scripts/build-wineserver.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+# Build a patched wineserver from the WineHQ source package.
+#
+# The rest of Wine still comes from the WineHQ binary package, so the wineserver
+# must be built from *exactly* the same source and package revision - the
+# wineserver protocol is version-locked and a mismatch makes Wine refuse to
+# start. That is why the source package version is pinned by the caller to the
+# same string used for `apt-get install winehq-stable=...`, and why every step
+# below fails loudly instead of falling back to something that merely looks
+# close enough.
+#
+# Usage: build-wineserver.sh <ubuntu-suite> <wine-package-version> <patch-file> <output-binary>
+#   e.g. build-wineserver.sh jammy 11.0.0.0~jammy-1 /patches/0001-....patch /out/wineserver
+
+set -eu
+
+SUITE="$1"
+WINE_PACKAGE_VERSION="$2"
+PATCH_FILE="$3"
+OUTPUT="$4"
+
+WORKDIR=/usr/src/wine-build
+
+[ -f "$PATCH_FILE" ] || { echo "ERROR: patch not found: $PATCH_FILE" >&2; exit 1; }
+
+# WineHQ's own apt repo, source component only. We never install binaries here.
+install -dm755 /etc/apt/keyrings
+curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key
+cat > /etc/apt/sources.list.d/winehq-src.sources <<EOF
+Types: deb-src
+URIs: https://dl.winehq.org/wine-builds/ubuntu
+Suites: ${SUITE}
+Components: main
+Signed-By: /etc/apt/keyrings/winehq-archive.key
+EOF
+apt-get update
+
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+# Exact revision or nothing: apt fails if this version is not in the index.
+# APT::Sandbox::User=root avoids the unsandboxed-download permission warning
+# turning into a failure when fetching into a root-owned directory.
+apt-get source -o APT::Sandbox::User=root "wine=${WINE_PACKAGE_VERSION}"
+
+SRCDIR="$(find . -maxdepth 1 -mindepth 1 -type d -name 'wine-*' -print -quit)"
+[ -n "$SRCDIR" ] || { echo "ERROR: unpacked wine source tree not found" >&2; exit 1; }
+cd "$SRCDIR"
+
+# Apply only the intended patch. No fuzz, no reversal guessing, no backups: if
+# the upstream code has moved, the build stops here rather than producing a
+# wineserver that silently lacks the fix.
+echo "Applying $PATCH_FILE"
+patch -p1 --batch --fuzz=0 --forward --no-backup-if-mismatch < "$PATCH_FILE"
+
+./configure --enable-win64 --without-x --without-freetype --without-mingw \
+    --disable-tests --without-alsa --without-pulse --without-oss --without-cups \
+    --without-fontconfig --without-gnutls --without-gstreamer --without-opengl \
+    --without-sdl --without-udev --without-usb --without-v4l2 --without-wayland \
+    --without-pcap --without-netapi --without-dbus --without-inotify >/dev/null
+
+# Only the server target; nothing else from this tree ships in the image.
+make -j"$(nproc)" server/wineserver
+strip server/wineserver
+
+install -Dm755 server/wineserver "$OUTPUT"
+"$OUTPUT" --version


### PR DESCRIPTION
This is @ifellows' work from #264 with the build-integration changes @traktuner asked for in [that review](https://github.com/JonathanTreffler/backblaze-personal-wine-container/pull/264#issuecomment-5054695854) applied on top. Their original commit is preserved unmodified as the first commit here, with authorship intact — all the analysis and the actual Wine fix are theirs.

#264 has had no reply for a week, and the requested changes were mechanical, so I did them rather than let the fix sit. **If @ifellows would rather carry these themselves, please close this** — `maintainerCanModify` is enabled on #264, so a maintainer can also just cherry-pick `3e86fde` straight onto their branch and keep the original PR.

Fixes #130. Fixes #186.

## Review feedback addressed

| Requested | Change |
|---|---|
| Pin the exact WineHQ package build | `ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1` / `11.0.0.0~noble-1`, driving `apt-get install winehq-stable=$WINE_PACKAGE_VERSION` |
| Build from the matching WineHQ source package for the same suite and revision, not a separate tarball | `apt-get source wine=$WINE_PACKAGE_VERSION` against a `deb-src` entry for the same suite |
| Move shared fetch/patch/build logic into a script | New `scripts/build-wineserver.sh`, called from both Dockerfiles; the duplicated inline `RUN` blocks are gone |
| Apply only the intended patch, fuzz disabled, fail if it no longer applies | Patch named explicitly (no `/patches/*.patch` glob), applied with `patch -p1 --batch --fuzz=0 --forward --no-backup-if-mismatch` |
| Build only `server/wineserver` | Unchanged |
| Copy the patched binary in before the prepared Wine prefix is created | Swap block moved above the prefix stage, so the existing `wineboot`, Winetricks and `wineserver -w` steps now exercise the patched server |
| Fail rather than silently combine mismatched revisions | Two guards, below |

Per the review, README and CHANGELOG changes from #264 are **not** included here.

## How the mismatch guard works now

The old `WINE_VERSION=11.0` string check caught a Wine *version* drift but not a package *revision* drift. Both halves are now pinned to one variable:

- the Wine binaries, via `apt-get install winehq-stable=$WINE_PACKAGE_VERSION`
- the `wineserver`, via `apt-get source wine=$WINE_PACKAGE_VERSION`

and the final stage asserts `dpkg-query -W -f='${Version}' winehq-stable` equals that pin, then that the packaged and patched `wineserver --version` agree, before swapping the binary.

A revision that isn't in the WineHQ repo now fails at apt time rather than later.

**Tradeoff worth calling out:** pinning means the image no longer picks up new WineHQ stable releases automatically — `WINE_PACKAGE_VERSION` has to be bumped in both Dockerfiles on each release, or the build fails loudly. That's the intended behaviour given the version-locked protocol, but it may be worth teaching `renovate.json` about it.

## Verification

Built with `--platform linux/amd64` (matching CI):

- **Both builder stages build clean**, exit 0, patched binary reports `Wine 11.0`. This includes `Dockerfile.ubuntu24`, which #264 noted was not yet built or tested.
- Pinned `apt-get source` fetches the exact dsc + orig tarball from WineHQ `deb-src`; `dpkg-source` extracts to `wine-11.0.0.0~jammy` / `~noble`; the patch applies clean (`patching file server/sock.c`, no fuzz).
- Final-stage guard passes on real values (`installed=11.0.0.0~jammy-1`, packaged and patched both `Wine 11.0`), and the shipped `wineserver` genuinely differs from the packaged `wineserver.orig`.

Negative tests, all failing the build as intended:

| Scenario | Result |
|---|---|
| Pinned source revision not in the repo | exit 100, `E: Can not find version '11.0.0.0~jammy-99' of package 'wine'` |
| Patch file missing | exit 1, `ERROR: patch not found:` |
| Patch context no longer matches | exit 1, `Hunk #1 FAILED`, `--fuzz=0` refuses to force it |

**Not verified locally:** the full image build. The prefix stage (`wineboot` + Winetricks .NET 4.8) is impractical to run under qemu emulation on my hardware, so it needs a CI run to confirm — that stage is otherwise unchanged, apart from now running against the patched `wineserver`.
