### PR TITLE
fix: fail loudly when the installer download does not return an installer

### DIFF
--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -147,7 +147,13 @@ handle_error() {
 fetch_and_install() {
     cd "$install_exe_path" || handle_error "INSTALLER: can't navigate to $install_exe_path"
     log_message "INSTALLER: Downloading latest Backblaze installer from $installer_url"
-    curl -L "$installer_url" --output "install_backblaze.exe" || handle_error "INSTALLER: error downloading from $installer_url"
+    # -f so an HTTP error fails here instead of saving the error page as the .exe.
+    curl -fL --retry 3 --retry-delay 2 "$installer_url" --output "install_backblaze.exe" || handle_error "INSTALLER: error downloading from $installer_url"
+    # An error or captive-portal page can still arrive as a 200, which -f won't
+    # catch. Windows executables start with "MZ"; anything else isn't one.
+    if [ "$(head -c 2 install_backblaze.exe 2>/dev/null)" != "MZ" ]; then
+        handle_error "INSTALLER: $installer_url did not return a Windows executable"
+    fi
     log_message "INSTALLER: Starting install_backblaze.exe (sign in via the web GUI to finish the install)"
     WINEARCH="$WINEARCH" WINEPREFIX="$WINEPREFIX" "$WINE" "install_backblaze.exe" || handle_error "INSTALLER: Failed to install Backblaze"
 }


### PR DESCRIPTION
`fetch_and_install` downloads the installer with:

```sh
curl -L "$installer_url" --output "install_backblaze.exe" || handle_error ...
```

Without `-f`, curl treats an HTTP error as a successful transfer. It saves the error page to `install_backblaze.exe`, exits 0, so the `|| handle_error` never fires and the script goes on to run an HTML file under Wine. What the user sees at that point has nothing to do with the real problem, which was that backblaze.com returned a 404 or a 5xx.

Ran the old and new commands against a local server to confirm the behaviour:

```
HTTP 404        | old(curl -L): exit0, wrote 469B | new(curl -fL): exitERR | magic-check: MZ-FAIL
real installer  | old(curl -L): exit0, wrote 17B  | new(curl -fL): exit0   | magic-check: MZ-ok
200 HTML portal | old(curl -L): exit0, wrote 33B  | new(curl -fL): exit0   | magic-check: MZ-FAIL
```

So this adds `-f`, plus `--retry 3` since a container starting at boot can easily get ahead of the network.

`-f` only covers HTTP error statuses. A captive portal or an ISP block answers 200 with an HTML body and still gets through (third row above), so there's also a check that the file starts with `MZ` before it's handed to Wine. Happy to drop that half if you'd rather keep the change to just `-f`.

Not using `--remove-on-error` for the partial-download case, as that needs curl 7.83 and Ubuntu 22.04 ships 7.81.

The other `curl` calls in the script look fine as they are: the two in `check_url_validity` deliberately inspect the status code themselves, and the version XML fetch only runs once that check has confirmed a 200.