### PR TITLE
feat: add ubuntu26 image + build process, update docs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dockerfile: [ubuntu22, ubuntu24]
+        dockerfile: [ubuntu22, ubuntu24, ubuntu26]
         include:
           # Ubuntu 22.04 is the default image and provides the main tags.
           - dockerfile: ubuntu22
@@ -35,6 +35,8 @@ jobs:
               ${{ github.ref_name }}
           - dockerfile: ubuntu24
             tags: ubuntu24
+          - dockerfile: ubuntu26
+            tags: ubuntu26
 
     steps:
       - name: Checkout repository
@@ -71,7 +73,7 @@ jobs:
       # Caching: GitHub Actions cache backend (type=gha) with mode=max so the
       # expensive build-time layers (apt/WineHQ install and the .NET 4.8 prefix
       # prep) are cached, not just the final image. A per-Dockerfile `scope`
-      # keeps the ubuntu22 and ubuntu24 matrix jobs from clobbering each other's
+      # keeps the ubuntu22, ubuntu24 and ubuntu26 matrix jobs from clobbering each other's
       # cache. Because the volatile rootfs/ is COPYed last in the Dockerfile, a
       # startapp.sh change reuses the cached wine/.NET layers and rebuilds fast.
       - name: Build and push Docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,28 +6,88 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Fix the ~0.7 Mbit/s per-connection upload slowdown affecting Backblaze client 9.0.1 and later under Wine ([#130](https://github.com/JonathanTreffler/backblaze-personal-wine-container/discussions/130), [#186](https://github.com/JonathanTreffler/backblaze-personal-wine-container/issues/186))
-
-## 1.11
+### Added
+- Add an officially built Ubuntu 26.04 image under the `ubuntu26` tag
 
 ### Changed
-- It seems that Backblaze has disabled our source of the known-good Backblaze installer on archive.org
-  Currently, all new installs will get the latest Backblaze version installed
-  Also, the autoupdate functionality is now disabled by default because of this change.
+- Pin and checksum the upstream winetricks script for reproducible image builds
 
-## 1.10
+### Fixed
+- Exit after a failed initial installation instead of leaving an empty container running
+
+## 2.1.1 - 2026-08-03
+
+### Fixed
+- Fail installer downloads on HTTP errors, retry transient failures, and reject
+  responses that do not contain a Windows executable ([#267](https://github.com/JonathanTreffler/backblaze-personal-wine-container/pull/267))
+
+## 2.1 - 2026-08-02
+
+### Fixed
+- Fix the ~0.7 Mbit/s per-connection upload slowdown affecting Backblaze client
+  9.0.1 and later under Wine by shipping a patched, version-matched `wineserver`
+  ([#130](https://github.com/JonathanTreffler/backblaze-personal-wine-container/discussions/130),
+  [#186](https://github.com/JonathanTreffler/backblaze-personal-wine-container/issues/186))
+
+## 2.0.1 - 2026-06-02
+
+### Fixed
+- Apply the supported-OS manifest to existing Wine prefixes so installations
+  upgraded from v1.x can update to Backblaze client v10
+
+## 2.0 - 2026-06-02
+
+### Added
+- Add an Ubuntu 24.04 image under the `ubuntu24` tag
+- Add opt-in masking of NFS, SMB, and CIFS mounts so Backblaze can treat them as
+  local fixed disks
+
+### Changed
+- Update to Wine 11 on Ubuntu 22.04 and Ubuntu 24.04
+- Prepare the Wine prefix and .NET Framework 4.8 inside the image for faster and
+  more reliable first-time installation
+- Disable Wine's virtual desktop by default
+- Rework Backblaze installation and update handling around the current upstream
+  installer
+
+### Removed
+- Stop building the end-of-life Ubuntu 18.04 and Ubuntu 20.04 images
+- Remove the obsolete pinned-installer mechanism; `FORCE_LATEST_UPDATE` remains
+  accepted as a deprecated no-op
+
+## 1.13 - 2025-02-24
+
+### Fixed
+- Fix a shell error introduced in version 1.12
+
+## 1.12 - 2025-02-24
+
+### Added
+- Install .NET Framework 4.8 for the Backblaze installer
+
+### Changed
+- Update Wine to version 10
+- Add `7zip` and `cabextract` as installer dependencies
+
+## 1.11 - 2024-06-23
+
+### Changed
+- Install the current Backblaze release because the previous known-good installer
+  is no longer available from the Internet Archive
+- Disable automatic Backblaze updates by default
+
+## 1.10 - 2024-06-16
 
 ### Changed
 - Update known-good Backblaze version to 9.0.1.777
 - Ubuntu 22 is now the default versioned image
 
-## 1.9
+## 1.9 - 2024-04-16
 
 ### Changed
 - Try to prevent forced Backblaze client updates
 
-## 1.8.1
+## 1.8.1 - 2024-03-30
 
 ### Changed
 - Optimize Dockerfiles to reduce layer count
@@ -38,20 +98,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update Backblaze automatically in the background
 - Make startapp log file location configurable by an env var (#129, thanks @brokeh)
 
-## 1.7.2 - 2024-02-24
+## 1.7.2 - 2024-02-23
 
 ### Changed
 - Update known-good Backblaze version to 9.0.1.767
 - Update Backblaze in the background 
 - Mark ubuntu18 tag as "End of Life" and remove ubuntu18 specific troubleshooting from readme
 
-
 ## 1.7.1 - 2024-02-15
 
 ### Changed
 - Set lower default values for DISPLAY_WIDTH and DISPLAY_HEIGHT
 
-## 1.7 - 2024-02-07
+## 1.7 - 2024-02-13
 
 ### Added
 - Automatically create symlinks for mounts (#110, thanks @xela1)
@@ -105,4 +164,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated Dependencies
 
-[Unreleased]: https://github.com/JonathanTreffler/backblaze-personal-wine-container/compare/v1.0...HEAD
+[Unreleased]: https://github.com/JonathanTreffler/backblaze-personal-wine-container/compare/v2.1.1...HEAD

--- a/Dockerfile.ubuntu22
+++ b/Dockerfile.ubuntu22
@@ -49,8 +49,9 @@ RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xvfb locales cabextract 7zip && \
     install -dm755 /etc/apt/keyrings && \
-    curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key && \
+    curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.asc && \
     curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources -o /etc/apt/sources.list.d/winehq-jammy.sources && \
+    sed -i 's#winehq-archive[.]key#winehq-archive.asc#' /etc/apt/sources.list.d/winehq-jammy.sources && \
     apt-get update && \
     apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
     curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_COMMIT}/src/winetricks" -o /usr/local/bin/winetricks && \

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -25,6 +25,8 @@ RUN chmod 755 /usr/local/bin/build-wineserver.sh && \
 FROM jlesage/baseimage-gui:ubuntu-24.04-v4.11.3
 ARG DEBIAN_FRONTEND=noninteractive
 ARG WINE_PACKAGE_VERSION
+ARG WINETRICKS_COMMIT=08304e81f9ac9a83c552a6bd78689040d174bf95
+ARG WINETRICKS_SHA256=954d17f56ae5f4d32eb083193a4a838c73ae5ff6b91765d93b0eab59cf2e7d29
 
 ENV WINEPREFIX=/config/wine/
 ENV LANG=en_US.UTF-8
@@ -39,9 +41,10 @@ ENV WINEDEBUG=-all
 ENV DISPLAY=:0
 
 # Install the latest stable WineHQ build with 32-bit support (Backblaze is a
-# 32-bit application). winetricks is fetched upstream instead of from apt, since
-# the Ubuntu package depends on the distro's own wine and would conflict with
-# WineHQ. cabextract + 7zip are needed by winetricks to install .NET 4.8.
+# 32-bit application). A pinned winetricks revision is fetched upstream instead
+# of from apt, since the Ubuntu package depends on the distro's own wine and
+# would conflict with WineHQ. cabextract + 7zip are needed by winetricks to
+# install .NET 4.8.
 RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xvfb locales cabextract 7zip && \
@@ -50,7 +53,9 @@ RUN dpkg --add-architecture i386 && \
     curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources -o /etc/apt/sources.list.d/winehq-noble.sources && \
     apt-get update && \
     apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
-    curl -fsSL https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -o /usr/local/bin/winetricks && \
+    curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_COMMIT}/src/winetricks" -o /usr/local/bin/winetricks && \
+    printf '%s  %s\n' "$WINETRICKS_SHA256" /usr/local/bin/winetricks > /tmp/winetricks.sha256 && \
+    sha256sum -c /tmp/winetricks.sha256 && rm /tmp/winetricks.sha256 && \
     chmod +x /usr/local/bin/winetricks && \
     sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && locale-gen && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ubuntu24
+++ b/Dockerfile.ubuntu24
@@ -49,8 +49,9 @@ RUN dpkg --add-architecture i386 && \
     apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xvfb locales cabextract 7zip && \
     install -dm755 /etc/apt/keyrings && \
-    curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key && \
+    curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.asc && \
     curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/noble/winehq-noble.sources -o /etc/apt/sources.list.d/winehq-noble.sources && \
+    sed -i 's#winehq-archive[.]key#winehq-archive.asc#' /etc/apt/sources.list.d/winehq-noble.sources && \
     apt-get update && \
     apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
     curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_COMMIT}/src/winetricks" -o /usr/local/bin/winetricks && \

--- a/Dockerfile.ubuntu26
+++ b/Dockerfile.ubuntu26
@@ -49,8 +49,9 @@ ENV DISPLAY=:0
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xvfb locales cabextract 7zip && \
     install -dm755 /etc/apt/keyrings && \
-    curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key && \
+    curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.asc && \
     curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/resolute/winehq-resolute.sources -o /etc/apt/sources.list.d/winehq-resolute.sources && \
+    sed -i 's#winehq-archive[.]key#winehq-archive.asc#' /etc/apt/sources.list.d/winehq-resolute.sources && \
     apt-get update && \
     apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
     curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_COMMIT}/src/winetricks" -o /usr/local/bin/winetricks && \

--- a/Dockerfile.ubuntu26
+++ b/Dockerfile.ubuntu26
@@ -45,8 +45,10 @@ ENV DISPLAY=:0
 # components and no i386 repository is needed. A pinned winetricks revision is
 # fetched upstream instead of from apt, since the Ubuntu package depends on the
 # distro's own wine and would conflict with WineHQ. cabextract + 7zip are needed
-# by winetricks to install .NET 4.8.
-RUN apt-get update && \
+# by winetricks to install .NET 4.8. The base image links /var/log to
+# /config/log, which must exist before systemd's postinst creates its journal.
+RUN mkdir -p /config/log && \
+    apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xvfb locales cabextract 7zip && \
     install -dm755 /etc/apt/keyrings && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.asc && \

--- a/Dockerfile.ubuntu26
+++ b/Dockerfile.ubuntu26
@@ -6,8 +6,8 @@
 # rebuilt, from the WineHQ *source* package for the exact same suite and package
 # revision as the winehq-stable binaries installed below - the wineserver
 # protocol is version-locked, so the two must come from one source revision.
-ARG WINE_PACKAGE_VERSION=11.0.0.0~jammy-1
-FROM ubuntu:22.04 AS wineserver-builder
+ARG WINE_PACKAGE_VERSION=11.0.0.0~resolute-1
+FROM ubuntu:26.04 AS wineserver-builder
 ARG DEBIAN_FRONTEND=noninteractive
 ARG WINE_PACKAGE_VERSION
 RUN apt-get update && \
@@ -18,11 +18,11 @@ COPY patches/ /patches/
 COPY scripts/build-wineserver.sh /usr/local/bin/build-wineserver.sh
 RUN chmod 755 /usr/local/bin/build-wineserver.sh && \
     /usr/local/bin/build-wineserver.sh \
-        jammy "$WINE_PACKAGE_VERSION" \
+        resolute "$WINE_PACKAGE_VERSION" \
         "/patches/0001-server-rearm-FD_WRITE-when-reporting-a-socket-not-wri.patch" \
         /out/wineserver
 
-FROM jlesage/baseimage-gui:ubuntu-22.04-v4.11.3
+FROM jlesage/baseimage-gui:ubuntu-26.04-v4.12.6
 ARG DEBIAN_FRONTEND=noninteractive
 ARG WINE_PACKAGE_VERSION
 ARG WINETRICKS_COMMIT=08304e81f9ac9a83c552a6bd78689040d174bf95
@@ -40,17 +40,17 @@ ENV WINEDEBUG=-all
 # Set DISPLAY to allow GUI programs to be run
 ENV DISPLAY=:0
 
-# Install the latest stable WineHQ build with 32-bit support (Backblaze is a
-# 32-bit application). A pinned winetricks revision is fetched upstream instead
-# of from apt, since the Ubuntu package depends on the distro's own wine and
-# would conflict with WineHQ. cabextract + 7zip are needed by winetricks to
-# install .NET 4.8.
-RUN dpkg --add-architecture i386 && \
-    apt-get update && \
+# Install the latest stable WineHQ build. Resolute's WineHQ packages use the
+# new WoW64 architecture, so the amd64 package also runs Backblaze's 32-bit
+# components and no i386 repository is needed. A pinned winetricks revision is
+# fetched upstream instead of from apt, since the Ubuntu package depends on the
+# distro's own wine and would conflict with WineHQ. cabextract + 7zip are needed
+# by winetricks to install .NET 4.8.
+RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl xvfb locales cabextract 7zip && \
     install -dm755 /etc/apt/keyrings && \
     curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key && \
-    curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/jammy/winehq-jammy.sources -o /etc/apt/sources.list.d/winehq-jammy.sources && \
+    curl -fsSL https://dl.winehq.org/wine-builds/ubuntu/dists/resolute/winehq-resolute.sources -o /etc/apt/sources.list.d/winehq-resolute.sources && \
     apt-get update && \
     apt-get install -y --install-recommends "winehq-stable=$WINE_PACKAGE_VERSION" && \
     curl -fsSL "https://raw.githubusercontent.com/Winetricks/winetricks/${WINETRICKS_COMMIT}/src/winetricks" -o /usr/local/bin/winetricks && \

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Here are the main components of this image:
 | latest | Latest stable version of the image based on ubuntu 22.04 |
 | ubuntu22 | Latest stable version of the image based on ubuntu 22.04 |
 | ubuntu24 | Latest stable version of the image based on ubuntu 24.04 |
-| v1.x | Versioned stable releases based on ubuntu 22.04 |
+| ubuntu26 | Latest stable version of the image based on ubuntu 26.04 |
+| vX.Y | Versioned stable releases based on ubuntu 22.04 |
 | main | Automatic build of the main branch (may be unstable) based on ubuntu 22.04 |
 
 The previous `ubuntu18` and `ubuntu20` images are end-of-life and are no longer built.

--- a/rootfs/startapp.sh
+++ b/rootfs/startapp.sh
@@ -138,7 +138,10 @@ fi
 
 handle_error() {
     echo "Error: $1" >> "$log_file"
-    start_app # start app even if the updater had a problem
+    if [ -f "$bzbui_exe" ]; then
+        start_app # keep the installed app available if only its update failed
+    fi
+    exit 1 # a failed initial install must not leave an empty container running
 }
 
 # Run the installer in the FOREGROUND so it blocks until the install -- including
@@ -160,7 +163,10 @@ fetch_and_install() {
 
 start_app() {
     log_message "STARTAPP: Starting Backblaze version $(cat "$local_version_file" 2>/dev/null)"
-    cd "$backblaze_dir" 2>/dev/null
+    if ! cd "$backblaze_dir" 2>/dev/null; then
+        log_message "STARTAPP: Backblaze directory not found: $backblaze_dir"
+        return 1
+    fi
     # Backblaze is single-instance: the first launch hides in the system tray (black
     # screen); a second launch shows its control-panel window. Launch a few times so
     # the window reliably appears after a (re)start.

--- a/scripts/build-wineserver.sh
+++ b/scripts/build-wineserver.sh
@@ -25,13 +25,13 @@ WORKDIR=/usr/src/wine-build
 
 # WineHQ's own apt repo, source component only. We never install binaries here.
 install -dm755 /etc/apt/keyrings
-curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.key
+curl -fsSL https://dl.winehq.org/wine-builds/winehq.key -o /etc/apt/keyrings/winehq-archive.asc
 cat > /etc/apt/sources.list.d/winehq-src.sources <<EOF
 Types: deb-src
 URIs: https://dl.winehq.org/wine-builds/ubuntu
 Suites: ${SUITE}
 Components: main
-Signed-By: /etc/apt/keyrings/winehq-archive.key
+Signed-By: /etc/apt/keyrings/winehq-archive.asc
 EOF
 apt-get update
 


### PR DESCRIPTION
In this PR:

- add an Ubuntu 26.04 image with jlesage’s baseimage-gui and Wine 11
- add `ubuntu26` to CI/release tags and update README/changelog
- pin winetricks in all Ubuntu images and fail cleanly on failed initial installs